### PR TITLE
Add notebook for scripted first-level FSL analyses using fMRIPrep data

### DIFF
--- a/books/examples/functional_imaging/Demo_fmriprep_FEAT.ipynb
+++ b/books/examples/functional_imaging/Demo_fmriprep_FEAT.ipynb
@@ -35,7 +35,7 @@
     "    </a>\n",
     "</div>\n",
     "\n",
-    "**Provenance:** This notebook adapts course materials and selected logic from the Fareri trust-game workflow code, but rewrites the steps so they can be followed directly in notebook cells. Full workflow repository: `https://github.com/tubric/fareri-2022-neuroimage`.\n",
+    "**Provenance:** This notebook adapts course materials and selected logic from the Fareri trust-game workflow code, but rewrites the steps so they can be followed directly in notebook cells. Full workflow repository: [tubric/fareri-2022-neuroimage](https://github.com/tubric/fareri-2022-neuroimage).\n",
     "\n",
     "**Acknowledgments:** This notebook was generated with assistance from ChatGPT-5 across several iterations and then revised by the instructor. The instructor reviewed the final content and takes responsibility for it.\n",
     "\n"
@@ -44,7 +44,9 @@
   {
    "cell_type": "markdown",
    "id": "a63b94c5",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
    "source": [
     "### Citation and Resources\n",
     "\n",
@@ -53,7 +55,7 @@
     "- **Smith et al. (2024)**: Smith, D. V., Ludwig, R. M., Dennison, J. B., Reeck, C., & Fareri, D. S. (2024). *An fMRI Dataset on Social Reward Processing and Decision Making in Younger and Older Adults.* **Scientific Data, 11**(1), 158. https://doi.org/10.1038/s41597-024-02931-y\n",
     "\n",
     "#### Full workflow repository\n",
-    "- **Fareri trust-game workflow repo**: `https://github.com/tubric/fareri-2022-neuroimage`\n",
+    "- **Fareri trust-game workflow repo**: [https://github.com/tubric/fareri-2022-neuroimage](https://github.com/tubric/fareri-2022-neuroimage)\n",
     "\n",
     "#### Tools included in this workflow\n",
     "- **fMRIPrep**: Esteban, O., Markiewicz, C. J., Blair, R. W., *et al.* (2019). fMRIPrep: a robust preprocessing pipeline for functional MRI. *Nature Methods, 16*, 111–116.\n",
@@ -72,7 +74,13 @@
   {
    "cell_type": "markdown",
    "id": "813ad334",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "## Table of content\n",
     "[1. Load software tools and import python libraries](#1.-Load-software-tools-and-import-python-libraries)  \n",
@@ -104,7 +112,7 @@
    "source": [
     "import module\n",
     "await module.load('fmriprep/25.2.5')\n",
-    "await module.load('fsl/6.0.7.16')\n",
+    "await module.load('fsl/6.0.7.22')\n",
     "await module.list()\n"
    ]
   },
@@ -116,7 +124,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!pip install pandas ipyniivue\n"
+    "!pip install pandas\n"
    ]
   },
   {
@@ -139,7 +147,13 @@
   {
    "cell_type": "markdown",
    "id": "63148d71",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Data preparation\n",
     "\n",
@@ -162,7 +176,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ab8bace5",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "scroll-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%bash\n",
@@ -200,7 +222,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7657a78b",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "!tree -L 3 ~/trust_example/templates\n",
@@ -258,7 +286,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8cdc8311",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "scroll-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%bash\n",
@@ -277,6 +313,9 @@
     "export OMP_NUM_THREADS=1\n",
     "export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=1\n",
     "\n",
+    "mkdir -p \"$HOME/freesurfer-subjects-dir\"\n",
+    "export SUBJECTS_DIR=\"$HOME/freesurfer-subjects-dir\"\n",
+    "\n",
     "# This command will likely take a couple of hours to finish.\n",
     "# If you want to confirm that it is still running, go back to the\n",
     "# Terminal and type: top\n",
@@ -289,20 +328,26 @@
     "  participant \\\n",
     "  --participant-label \"$sub\" \\\n",
     "  --stop-on-first-crash \\\n",
-    "  --skip-bids-validation \\\n",
     "  --fs-license-file \"$FS_LIC\" \\\n",
+    "  --fs-subjects-dir \"$SUBJECTS_DIR\" \\\n",
     "  --fs-no-reconall \\\n",
     "  --output-spaces MNI152NLin6Asym:res-2 \\\n",
     "  --nthreads 12 \\\n",
     "  --omp-nthreads 1 \\\n",
-    "  --mem-mb 30000 \\\n",
+    "  --mem-mb 12000 \\\n",
     "  -w \"$WORK_DIR\"\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "230e5a4b",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "When fMRIPrep finishes, the files we care about most for FEAT are:\n",
     "\n",
@@ -352,7 +397,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5cfd09ba",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "confounds_tsv = base_dir / \"derivatives\" / \"fmriprep\" / \"sub-104\" / \"func\" / \"sub-104_task-trust_run-01_desc-confounds_timeseries.tsv\"\n",
@@ -485,7 +536,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a0364f40",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%bash\n",
@@ -528,7 +585,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cb881a26",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "scroll-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "rendered_fsf = base_dir / \"derivatives\" / \"fsl\" / \"sub-104\" / \"L1_sub-104_task-trust_model-01_run-01_act.fsf\"\n",
@@ -540,7 +605,13 @@
   {
    "cell_type": "markdown",
    "id": "128e36a0",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Run first-level FEAT\n",
     "\n",
@@ -565,6 +636,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d0203fb1",
    "metadata": {},
    "source": [
     "## 8. Fix FEAT registration for fMRIPrep-preprocessed data\n",
@@ -572,8 +644,7 @@
     "Because the functional image already came out of fMRIPrep in standard space, FEAT's usual registration outputs are not the right ones to trust here.  \n",
     "The next cell follows the same post-FEAT registration fix used in the original `L1stats.sh` script.\n",
     "\n",
-    "This is based on the NeuroStars note referenced in that script:  \n",
-    "https://neurostars.org/t/performing-full-glm-analysis-with-fsl-on-the-bold-images-preprocessed-by-fmriprep-without-re-registering-the-data-to-the-mni-space/784/3\n",
+    "This is based on the [NeuroStars post](https://neurostars.org/t/performing-full-glm-analysis-with-fsl-on-the-bold-images-preprocessed-by-fmriprep-without-re-registering-the-data-to-the-mni-space/784/3) referenced in that script.  \n",
     "\n",
     "In plain language, this step tells FEAT to treat the input as already being in standard space, so the registration files inside the `.feat` directory do not point to misleading transforms.\n"
    ]
@@ -581,6 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6f917ce7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -747,13 +819,21 @@
     "neurodesktop_version = os.environ.get('JUPYTER_IMAGE', 'unknown').split(':')[-1]\n",
     "print(f\"Neurodesktop version: {neurodesktop_version}\")\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "777d7410-f86e-4da6-a76a-71df8f09d5ae",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:base] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-base-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -765,7 +845,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.9"
+   "version": "3.13.12"
   },
   "rise": {
    "scroll": true,

--- a/books/examples/functional_imaging/Demo_fmriprep_FEAT.ipynb
+++ b/books/examples/functional_imaging/Demo_fmriprep_FEAT.ipynb
@@ -1,0 +1,777 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ba347a06",
+   "metadata": {},
+   "source": [
+    "# Scripted First-Level Analyses in FSL using fMRIPrep data\n",
+    "\n",
+    "This notebook walks through a simple, novice-friendly workflow in **Neurodesk EDU**:\n",
+    "\n",
+    "1. install one OpenNeuro dataset and get one subject  \n",
+    "2. run **fMRIPrep** for that subject and extract FEAT-ready confounds  \n",
+    "3. convert BIDS `events.tsv` files to FSL 3-column EV files  \n",
+    "4. render and run a first-level FEAT model from a trust-game FEAT template  \n",
+    "5. make a first pass at viewing the result in **NiiVue**\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ebf9816",
+   "metadata": {},
+   "source": [
+    "**Author**: <div style=\"margin-top: 10px;\">\n",
+    "    <a href=\"https://orcid.org/0000-0001-5754-9633\" target=\"_blank\" style=\"color: #0066cc;\">\n",
+    "        <i class=\"fab fa-orcid\"></i> David V. Smith\n",
+    "    </a>\n",
+    "</div>\n",
+    "\n",
+    "**Date**: April 2, 2026  \n",
+    "\n",
+    "**License**: <div style=\"margin-top: 10px;\">\n",
+    "    <a href=\"https://opensource.org/licenses/MIT\" target=\"_blank\" style=\"color: #0066cc;\">\n",
+    "        <i class=\"fas fa-balance-scale\"></i> MIT License\n",
+    "    </a>\n",
+    "</div>\n",
+    "\n",
+    "**Provenance:** This notebook adapts course materials and selected logic from the Fareri trust-game workflow code, but rewrites the steps so they can be followed directly in notebook cells. Full workflow repository: `https://github.com/tubric/fareri-2022-neuroimage`.\n",
+    "\n",
+    "**Acknowledgments:** This notebook was generated with assistance from ChatGPT-5 across several iterations and then revised by the instructor. The instructor reviewed the final content and takes responsibility for it.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a63b94c5",
+   "metadata": {},
+   "source": [
+    "### Citation and Resources\n",
+    "\n",
+    "#### Study-specific references\n",
+    "- **Fareri et al. (2022)**: Fareri, D. S., Hackett, K., Tepfer, L. J., Kelly, V., Henninger, N., Reeck, C., Giovannetti, T., & Smith, D. V. (2022). *Age-related differences in ventral striatal and default mode network function during reciprocated trust.* **NeuroImage, 256**, 119267. https://doi.org/10.1016/j.neuroimage.2022.119267\n",
+    "- **Smith et al. (2024)**: Smith, D. V., Ludwig, R. M., Dennison, J. B., Reeck, C., & Fareri, D. S. (2024). *An fMRI Dataset on Social Reward Processing and Decision Making in Younger and Older Adults.* **Scientific Data, 11**(1), 158. https://doi.org/10.1038/s41597-024-02931-y\n",
+    "\n",
+    "#### Full workflow repository\n",
+    "- **Fareri trust-game workflow repo**: `https://github.com/tubric/fareri-2022-neuroimage`\n",
+    "\n",
+    "#### Tools included in this workflow\n",
+    "- **fMRIPrep**: Esteban, O., Markiewicz, C. J., Blair, R. W., *et al.* (2019). fMRIPrep: a robust preprocessing pipeline for functional MRI. *Nature Methods, 16*, 111–116.\n",
+    "- **FSL / FEAT**: Jenkinson, M., Beckmann, C. F., Behrens, T. E. J., Woolrich, M. W., & Smith, S. M. (2012). FSL. *NeuroImage, 62*, 782–790.\n",
+    "- **DataLad**: Halchenko, Y. O., Meyer, K., Poldrack, B., *et al.* (2021). DataLad: distributed system for joint management of code, data, and their relationship. *Journal of Open Source Software, 6*, 3262.\n",
+    "- **bidsutils / BIDSto3col.sh**: Tom Nichols and contributors. `bids-standard/bidsutils`.\n",
+    "- **NiiVue / ipyniivue** for interactive image viewing in Jupyter.\n",
+    "\n",
+    "#### Dataset\n",
+    "- **OpenNeuro ds003745** (trust game dataset used in class materials and labs)\n",
+    "\n",
+    "#### Educational resources\n",
+    "- Course labs on Neurodesk, fMRIPrep, FEAT, and 3-column event files.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "813ad334",
+   "metadata": {},
+   "source": [
+    "## Table of content\n",
+    "[1. Load software tools and import python libraries](#1.-Load-software-tools-and-import-python-libraries)  \n",
+    "[2. Data preparation](#2.-Data-preparation)  \n",
+    "[3. Run fMRIPrep for one subject](#3.-Run-fMRIPrep-for-one-subject)  \n",
+    "[4. Make a FEAT confounds file](#4.-Make-a-FEAT-confounds-file)  \n",
+    "[5. Convert events.tsv to 3-column files](#5.-Convert-events.tsv-to-3-column-files)  \n",
+    "[6. Render the FEAT template](#6.-Render-the-FEAT-template)  \n",
+    "[7. Run first-level FEAT](#7.-Run-first-level-FEAT)  \n",
+    "[8. Fix FEAT registration for fMRIPrep-preprocessed data](#8.-Fix-FEAT-registration-for-fMRIPrep-preprocessed-data)  \n",
+    "[9. Results](#9.-Results)  \n",
+    "[10. Dependencies in Jupyter/Python](#10.-Dependencies-in-Jupyter/Python)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cce99966",
+   "metadata": {},
+   "source": [
+    "## 1. Load software tools and import python libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67f7c963",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import module\n",
+    "await module.load('fmriprep/25.2.5')\n",
+    "await module.load('fsl/6.0.7.16')\n",
+    "await module.list()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f219cbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "!pip install pandas ipyniivue\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "934aaefa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import os\n",
+    "import glob\n",
+    "import pandas as pd\n",
+    "from IPython.display import display, Markdown, Image\n",
+    "\n",
+    "base_dir = Path.home() / \"trust_example\"\n",
+    "print(base_dir)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63148d71",
+   "metadata": {},
+   "source": [
+    "## 2. Data preparation\n",
+    "\n",
+    "We will keep everything for this example in one folder directly under the home directory:\n",
+    "\n",
+    "`~/trust_example`\n",
+    "\n",
+    "That makes the paths easy to read, and it also makes it easier to rerun or delete the whole example later if you want a clean start.\n",
+    "\n",
+    "Inside that folder, we will make a few subdirectories:\n",
+    "\n",
+    "- `templates/` for the FEAT template  \n",
+    "- `bids/` for the OpenNeuro dataset  \n",
+    "- `derivatives/` for fMRIPrep output, confounds, EV files, and FEAT output  \n",
+    "- `scratch/` for temporary working files  \n",
+    "- `bidsutils/` for Tom Nichols' `BIDSto3col.sh`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab8bace5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -e\n",
+    "\n",
+    "EXAMPLE_DIR=\"$HOME/trust_example\"\n",
+    "\n",
+    "mkdir -p \"$EXAMPLE_DIR\"\n",
+    "cd \"$EXAMPLE_DIR\"\n",
+    "\n",
+    "# Keep the example organized in one project folder.\n",
+    "mkdir -p templates bids derivatives scratch\n",
+    "\n",
+    "# Copy the one FEAT template we need.\n",
+    "curl -L \\\n",
+    "  https://raw.githubusercontent.com/tubric/fareri-2022-neuroimage/main/templates/L1_task-trust_model-01_type-act.fsf \\\n",
+    "  -o templates/L1_task-trust_model-01_type-act.fsf\n",
+    "\n",
+    "# Install bidsutils separately so we can use BIDSto3col.sh.\n",
+    "if [ ! -d bidsutils ]; then\n",
+    "  git clone --depth 1 https://github.com/bids-standard/bidsutils.git\n",
+    "fi\n",
+    "\n",
+    "# Install the OpenNeuro dataset skeleton and get the full subject recursively.\n",
+    "cd bids\n",
+    "if [ ! -d ds003745 ]; then\n",
+    "  datalad install https://github.com/OpenNeuroDatasets/ds003745.git\n",
+    "fi\n",
+    "\n",
+    "cd ds003745\n",
+    "datalad get -r sub-104\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7657a78b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!tree -L 3 ~/trust_example/templates\n",
+    "!tree -L 3 ~/trust_example/bids/ds003745/sub-104\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6580e029",
+   "metadata": {},
+   "source": [
+    "The example below uses:\n",
+    "\n",
+    "- **subject**: `104`\n",
+    "- **task**: `trust`\n",
+    "- **run**: `01`\n",
+    "\n",
+    "That keeps the notebook manageable, but the same logic can be repeated for the other runs.\n",
+    "\n",
+    "For teaching purposes, one run is a nice compromise: the model is still realistic, but the files and paths stay simple enough to follow line by line.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fbfe00f",
+   "metadata": {},
+   "source": [
+    "## 3. Run fMRIPrep for one subject\n",
+    "\n",
+    "The next cell runs fMRIPrep on one participant and writes the outputs under `~/trust_example/derivatives/fmriprep`.\n",
+    "\n",
+    "A few practical notes:\n",
+    "\n",
+    "- the FreeSurfer license file should exist at `~/.license`\n",
+    "- we turn off BIDS validation here because this dataset is known to be BIDS-compatible, but the validator is causing trouble in this environment\n",
+    "- this command will likely take **a couple of hours** to run\n",
+    "- if you are wondering whether it is still running, go back to the **Terminal** and type `top`\n",
+    "- the `antsRegistration` step is especially slow, so long stretches of apparent inactivity are normal\n",
+    "- we use `MNI152NLin6Asym:res-2` so the preprocessed BOLD file lands on a 2 mm MNI grid that is easy to use alongside standard FSL templates and atlases\n",
+    "\n",
+    "One important detail: the `res-2` part controls the **output grid** of the resampled BOLD files. It does **not** change the resolution used for the underlying nonlinear normalization.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c40fa02d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls -l ~/.license\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8cdc8311",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -e\n",
+    "\n",
+    "EXAMPLE_DIR=\"$HOME/trust_example\"\n",
+    "\n",
+    "sub=104\n",
+    "BIDS_DIR=\"$EXAMPLE_DIR/bids/ds003745\"\n",
+    "OUT_DIR=\"$EXAMPLE_DIR/derivatives/fmriprep\"\n",
+    "WORK_DIR=\"$EXAMPLE_DIR/scratch/fmriprep_work\"\n",
+    "FS_LIC=\"$HOME/.license\"\n",
+    "\n",
+    "mkdir -p \"$OUT_DIR\" \"$WORK_DIR\"\n",
+    "\n",
+    "export OMP_NUM_THREADS=1\n",
+    "export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=1\n",
+    "\n",
+    "# This command will likely take a couple of hours to finish.\n",
+    "# If you want to confirm that it is still running, go back to the\n",
+    "# Terminal and type: top\n",
+    "# The antsRegistration process is especially slow and can run for\n",
+    "# a long time without printing much new output.\n",
+    "\n",
+    "fmriprep \\\n",
+    "  \"$BIDS_DIR\" \\\n",
+    "  \"$OUT_DIR\" \\\n",
+    "  participant \\\n",
+    "  --participant-label \"$sub\" \\\n",
+    "  --stop-on-first-crash \\\n",
+    "  --skip-bids-validation \\\n",
+    "  --fs-license-file \"$FS_LIC\" \\\n",
+    "  --fs-no-reconall \\\n",
+    "  --output-spaces MNI152NLin6Asym:res-2 \\\n",
+    "  --nthreads 12 \\\n",
+    "  --omp-nthreads 1 \\\n",
+    "  --mem-mb 30000 \\\n",
+    "  -w \"$WORK_DIR\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "230e5a4b",
+   "metadata": {},
+   "source": [
+    "When fMRIPrep finishes, the files we care about most for FEAT are:\n",
+    "\n",
+    "- the HTML report\n",
+    "- the preprocessed BOLD file for the run we want\n",
+    "- the confounds table for that run\n",
+    "\n",
+    "Because we wrote the outputs into `~/trust_example/derivatives/fmriprep`, the next steps can keep using the same paths throughout the notebook.\n",
+    "\n",
+    "If the HTML report does not open correctly inside Neurodesktop, open it through **JupyterLab** instead. It is worth checking the report before moving on, because bad preprocessing or bad alignment will usually be easier to catch here than later in the FEAT output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a05ae4f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!find ~/trust_example/derivatives/fmriprep -name \"sub-104.html\"\n",
+    "!find ~/trust_example/derivatives/fmriprep -name \"*run-01*desc-preproc_bold.nii.gz\"\n",
+    "!find ~/trust_example/derivatives/fmriprep -name \"*run-01*desc-confounds_timeseries.tsv\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f52ce60",
+   "metadata": {},
+   "source": [
+    "## 4. Make a FEAT confounds file\n",
+    "\n",
+    "Here we take the fMRIPrep confounds table for one run and save a FEAT-ready text file.\n",
+    "\n",
+    "We keep:\n",
+    "- cosine regressors\n",
+    "- non-steady-state regressors\n",
+    "- 6 motion parameters\n",
+    "- the first 6 aCompCor components\n",
+    "- framewise displacement, if it exists\n",
+    "\n",
+    "FEAT wants a plain text file **without a header**, so we write the output that way.\n",
+    "\n",
+    "This is a good example of why notebook workflows can be useful for teaching: you can see exactly which nuisance regressors are being kept, rather than hiding that logic inside a separate script.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5cfd09ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "confounds_tsv = base_dir / \"derivatives\" / \"fmriprep\" / \"sub-104\" / \"func\" / \"sub-104_task-trust_run-01_desc-confounds_timeseries.tsv\"\n",
+    "confounds = pd.read_csv(confounds_tsv, sep=\"\t\")\n",
+    "\n",
+    "# Keep a simple but still realistic set of nuisance regressors.\n",
+    "cosine_cols = [c for c in confounds.columns if c.startswith(\"cosine\")]\n",
+    "nss_cols = [c for c in confounds.columns if c.startswith(\"non_steady_state\")]\n",
+    "motion_cols = [\"trans_x\", \"trans_y\", \"trans_z\", \"rot_x\", \"rot_y\", \"rot_z\"]\n",
+    "acompcor_cols = [c for c in confounds.columns if c.startswith(\"a_comp_cor_\")][:6]\n",
+    "fd_cols = [\"framewise_displacement\"] if \"framewise_displacement\" in confounds.columns else []\n",
+    "\n",
+    "keep_cols = cosine_cols + nss_cols + motion_cols + acompcor_cols + fd_cols\n",
+    "feat_confounds = confounds[keep_cols].fillna(0)\n",
+    "\n",
+    "out_dir = base_dir / \"derivatives\" / \"fsl\" / \"confounds\" / \"sub-104\"\n",
+    "out_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "out_file = out_dir / \"sub-104_task-trust_run-01_desc-fslConfounds.tsv\"\n",
+    "feat_confounds.to_csv(out_file, sep=\"\t\", header=False, index=False)\n",
+    "\n",
+    "print(out_file)\n",
+    "print(feat_confounds.shape)\n",
+    "feat_confounds.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bac784b",
+   "metadata": {},
+   "source": [
+    "## 5. Convert events.tsv to 3-column files\n",
+    "\n",
+    "This step uses `BIDSto3col.sh` from **bidsutils** and keeps the logic to one run.\n",
+    "\n",
+    "`BIDSto3col.sh` reads the BIDS events file and writes one 3-column text file per event type.  \n",
+    "Each output file has three columns:\n",
+    "\n",
+    "1. onset  \n",
+    "2. duration  \n",
+    "3. weight\n",
+    "\n",
+    "Those output files are exactly the kind of timing files FEAT expects for custom EVs, so this is one of the main bridges between a BIDS dataset and an FSL first-level model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a05ff17f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -e\n",
+    "\n",
+    "EXAMPLE_DIR=\"$HOME/trust_example\"\n",
+    "\n",
+    "sub=104\n",
+    "run=01\n",
+    "events_tsv=\"$EXAMPLE_DIR/bids/ds003745/sub-${sub}/func/sub-${sub}_task-trust_run-${run}_events.tsv\"\n",
+    "out_base=\"$EXAMPLE_DIR/derivatives/fsl/EVfiles/sub-${sub}/trust/run-${run}\"\n",
+    "\n",
+    "mkdir -p \"$(dirname \"$out_base\")\"\n",
+    "\n",
+    "# This creates one 3-column file per event type found in the BIDS events file.\n",
+    "bash \"$EXAMPLE_DIR/bidsutils/BIDSto3col/BIDSto3col.sh\" \"$events_tsv\" \"$out_base\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d39cb13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls ~/trust_example/derivatives/fsl/EVfiles/sub-104/trust\n",
+    "!head -n 5 ~/trust_example/derivatives/fsl/EVfiles/sub-104/trust/run-01_choice_computer.txt\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f421412",
+   "metadata": {},
+   "source": [
+    "## 6. Render the FEAT template\n",
+    "\n",
+    "The template file already contains the FEAT model structure.  \n",
+    "What changes from subject to subject and run to run are the **paths** and a few settings.\n",
+    "\n",
+    "This is a useful pattern for reproducible work: keep the design mostly fixed, and then fill in the parts that should vary across runs.\n",
+    "\n",
+    "### Placeholders we replace\n",
+    "- `OUTPUT` → where the `.feat` directory should be written  \n",
+    "- `DATA` → the preprocessed BOLD file from fMRIPrep  \n",
+    "- `EVDIR` → the prefix used by the EV timing files  \n",
+    "- `MISSED_TRIAL` → path to the optional missed-trial EV file  \n",
+    "- `EV_SHAPE` → `3` if the missed-trial file exists, otherwise `10` for an empty EV  \n",
+    "- `SMOOTH` → smoothing kernel in mm  \n",
+    "- `CONFOUNDEVS` → the confounds file we just created\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cae2365a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "template_text = (base_dir / \"templates\" / \"L1_task-trust_model-01_type-act.fsf\").read_text()\n",
+    "\n",
+    "for token in [\"OUTPUT\", \"DATA\", \"EVDIR\", \"MISSED_TRIAL\", \"EV_SHAPE\", \"SMOOTH\", \"CONFOUNDEVS\"]:\n",
+    "    print(f\"--- lines containing {token} ---\")\n",
+    "    for line in template_text.splitlines():\n",
+    "        if token in line:\n",
+    "            print(line)\n",
+    "    print()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "887901c2",
+   "metadata": {},
+   "source": [
+    "The next cell renders a new `.fsf` file. Each variable is written out explicitly so you can see what is being inserted.\n",
+    "\n",
+    "Even if you do not remember every line of FEAT syntax, the important lesson is that the `.fsf` file is just text. That means you can inspect it, edit it, and generate it systematically.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0364f40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -e\n",
+    "\n",
+    "EXAMPLE_DIR=\"$HOME/trust_example\"\n",
+    "\n",
+    "TASK=trust\n",
+    "SMOOTH=6\n",
+    "sub=104\n",
+    "run=01\n",
+    "\n",
+    "OUTPUT=\"$EXAMPLE_DIR/derivatives/fsl/sub-${sub}/L1_task-${TASK}_model-01_type-act_run-${run}_sm-${SMOOTH}\"\n",
+    "DATA=\"$EXAMPLE_DIR/derivatives/fmriprep/sub-${sub}/func/sub-${sub}_task-${TASK}_run-${run}_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz\"\n",
+    "CONFOUNDEVS=\"$EXAMPLE_DIR/derivatives/fsl/confounds/sub-${sub}/sub-${sub}_task-${TASK}_run-${run}_desc-fslConfounds.tsv\"\n",
+    "EVDIR=\"$EXAMPLE_DIR/derivatives/fsl/EVfiles/sub-${sub}/${TASK}/run-${run}\"\n",
+    "MISSED_TRIAL=\"${EVDIR}_missed_trial.txt\"\n",
+    "\n",
+    "if [ -e \"$MISSED_TRIAL\" ]; then\n",
+    "  EV_SHAPE=3\n",
+    "else\n",
+    "  EV_SHAPE=10\n",
+    "fi\n",
+    "\n",
+    "mkdir -p \"$(dirname \"$OUTPUT\")\"\n",
+    "\n",
+    "sed \\\n",
+    "  -e \"s@OUTPUT@${OUTPUT}@g\" \\\n",
+    "  -e \"s@DATA@${DATA}@g\" \\\n",
+    "  -e \"s@EVDIR@${EVDIR}@g\" \\\n",
+    "  -e \"s@MISSED_TRIAL@${MISSED_TRIAL}@g\" \\\n",
+    "  -e \"s@EV_SHAPE@${EV_SHAPE}@g\" \\\n",
+    "  -e \"s@SMOOTH@${SMOOTH}@g\" \\\n",
+    "  -e \"s@CONFOUNDEVS@${CONFOUNDEVS}@g\" \\\n",
+    "  \"$EXAMPLE_DIR/templates/L1_task-trust_model-01_type-act.fsf\" \\\n",
+    "  > \"$EXAMPLE_DIR/derivatives/fsl/sub-${sub}/L1_sub-${sub}_task-${TASK}_model-01_run-${run}_act.fsf\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb881a26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rendered_fsf = base_dir / \"derivatives\" / \"fsl\" / \"sub-104\" / \"L1_sub-104_task-trust_model-01_run-01_act.fsf\"\n",
+    "print(rendered_fsf)\n",
+    "print()\n",
+    "print(rendered_fsf.read_text()[:4000])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "128e36a0",
+   "metadata": {},
+   "source": [
+    "## 7. Run first-level FEAT\n",
+    "\n",
+    "This command runs FEAT on the rendered design file.\n",
+    "\n",
+    "At this point, the main conceptual pieces are in place: preprocessed data, confounds, EV timing files, and a rendered design file. FEAT now uses those pieces to estimate the first-level GLM.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "981c9aa2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -e\n",
+    "\n",
+    "# Run FEAT on the rendered first-level design file.\n",
+    "feat \"$HOME/trust_example/derivatives/fsl/sub-104/L1_sub-104_task-trust_model-01_run-01_act.fsf\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Fix FEAT registration for fMRIPrep-preprocessed data\n",
+    "\n",
+    "Because the functional image already came out of fMRIPrep in standard space, FEAT's usual registration outputs are not the right ones to trust here.  \n",
+    "The next cell follows the same post-FEAT registration fix used in the original `L1stats.sh` script.\n",
+    "\n",
+    "This is based on the NeuroStars note referenced in that script:  \n",
+    "https://neurostars.org/t/performing-full-glm-analysis-with-fsl-on-the-bold-images-preprocessed-by-fmriprep-without-re-registering-the-data-to-the-mni-space/784/3\n",
+    "\n",
+    "In plain language, this step tells FEAT to treat the input as already being in standard space, so the registration files inside the `.feat` directory do not point to misleading transforms.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -e\n",
+    "\n",
+    "OUTPUT=\"$HOME/trust_example/derivatives/fsl/sub-104/L1_task-trust_model-01_type-act_run-01_sm-6\"\n",
+    "\n",
+    "# fix registration as per NeuroStars post:\n",
+    "# https://neurostars.org/t/performing-full-glm-analysis-with-fsl-on-the-bold-images-preprocessed-by-fmriprep-without-re-registering-the-data-to-the-mni-space/784/3\n",
+    "mkdir -p ${OUTPUT}.feat/reg\n",
+    "ln -sf $FSLDIR/etc/flirtsch/ident.mat ${OUTPUT}.feat/reg/example_func2standard.mat\n",
+    "ln -sf $FSLDIR/etc/flirtsch/ident.mat ${OUTPUT}.feat/reg/standard2example_func.mat\n",
+    "ln -sf ${OUTPUT}.feat/mean_func.nii.gz ${OUTPUT}.feat/reg/standard.nii.gz\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8f4b333",
+   "metadata": {},
+   "source": [
+    "## 9. Results\n",
+    "\n",
+    "The FEAT output directory should now contain the standard report, design matrix, and statistical maps.\n",
+    "\n",
+    "A few files worth checking first are:\n",
+    "\n",
+    "- `report.html`\n",
+    "- `design.png`\n",
+    "- `thresh_zstat1.nii.gz`\n",
+    "- `thresh_zstat2.nii.gz`\n",
+    "- `thresh_zstat10.nii.gz`\n",
+    "\n",
+    "This is also a good point to slow down and inspect the outputs before interpreting anything. Make sure the design looks sensible, the report opens, and the expected thresholded maps actually exist.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd5d764b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "feat_dir = base_dir / \"derivatives\" / \"fsl\" / \"sub-104\" / \"L1_task-trust_model-01_type-act_run-01_sm-6.feat\"\n",
+    "\n",
+    "for rel in [\n",
+    "    \"report.html\",\n",
+    "    \"design.png\",\n",
+    "    \"thresh_zstat1.nii.gz\",\n",
+    "    \"thresh_zstat2.nii.gz\",\n",
+    "    \"thresh_zstat10.nii.gz\",\n",
+    "]:\n",
+    "    p = feat_dir / rel\n",
+    "    print(f\"{p}: {p.exists()}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9482aa0c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "design_png = feat_dir / \"design.png\"\n",
+    "if design_png.exists():\n",
+    "    display(Image(filename=str(design_png)))\n",
+    "else:\n",
+    "    print(\"Run FEAT first, then come back to this cell.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c99aa49e",
+   "metadata": {},
+   "source": [
+    "### Optional: try a quick NiiVue visualization\n",
+    "\n",
+    "This cell overlays a thresholded FEAT result on the example functional image from the same run.\n",
+    "\n",
+    "Here we use `thresh_zstat10.nii.gz`, which corresponds to **reciprocate > defect**. In this task, that contrast is roughly reward-related, so even in a single run you may see activation in the **ventral striatum** and nearby reward-sensitive regions.\n",
+    "\n",
+    "A few learning notes:\n",
+    "\n",
+    "- `example_func.nii.gz` gives you a background image in the same space as the FEAT results, but it's a little blurry\n",
+    "- `MNI152_T1_2mm_brain.nii.gz` is a T1 background in MNI space and should be better for visualization. \n",
+    "- `thresh_zstat10.nii.gz` is already thresholded, so the overlay is easier to interpret\n",
+    "- if your notebook shows nothing, first confirm that the `.feat` directory exists and that `thresh_zstat10.nii.gz` is really there\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c12c5e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from IPython.display import display\n",
+    "from ipyniivue import NiiVue\n",
+    "import nibabel as nib\n",
+    "import numpy as np\n",
+    "\n",
+    "# FEAT background and contrast map from the same run\n",
+    "# bg = str(feat_dir / \"example_func.nii.gz\")\n",
+    "bg = \"/cvmfs/neurodesk.ardc.edu.au/containers/fsl_6.0.7.16_20250131/fsl_6.0.7.16_20250131.simg/opt/fsl-6.0.7.16/data/standard/MNI152_T1_2mm_brain.nii.gz\"\n",
+    "zmap = str(feat_dir / \"thresh_zstat10.nii.gz\")  # reciprocate > defect\n",
+    "\n",
+    "print(\"Background exists:\", Path(bg).exists(), bg)\n",
+    "print(\"Contrast exists:\", Path(zmap).exists(), zmap)\n",
+    "\n",
+    "if Path(bg).exists() and Path(zmap).exists():\n",
+    "    # Load the EPI background and choose a sensible display window\n",
+    "    epi = nib.load(bg).get_fdata()\n",
+    "    epi_nonzero = epi[epi > 0]\n",
+    "\n",
+    "    lo = float(np.percentile(epi_nonzero, 2))\n",
+    "    hi = float(np.percentile(epi_nonzero, 98))\n",
+    "\n",
+    "    nv = NiiVue()\n",
+    "    nv.load_volumes([\n",
+    "        {\n",
+    "            \"path\": bg,\n",
+    "            \"name\": \"example_func\",\n",
+    "            \"colormap\": \"gray\",\n",
+    "            \"opacity\": 1.0,\n",
+    "            \"cal_min\": lo,\n",
+    "            \"cal_max\": hi\n",
+    "        },\n",
+    "        {\n",
+    "            \"path\": zmap,\n",
+    "            \"name\": \"reciprocate > defect\",\n",
+    "            \"colormap\": \"red\",\n",
+    "            \"opacity\": 0.45\n",
+    "        }\n",
+    "    ])\n",
+    "    display(nv)\n",
+    "else:\n",
+    "    print(\"Run FEAT first, then come back to this cell.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce7f5748",
+   "metadata": {},
+   "source": [
+    "## 10. Dependencies in Jupyter/Python\n",
+    "- Using the package [watermark](https://github.com/rasbt/watermark) to document system environment and software versions used in this notebook, alongside the Neurodesktop version extracted from the `JUPYTER_IMAGE` environment variable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24b30dc8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "%load_ext watermark\n",
+    "\n",
+    "%watermark\n",
+    "%watermark --iversions\n",
+    "\n",
+    "neurodesktop_version = os.environ.get('JUPYTER_IMAGE', 'unknown').split(':')[-1]\n",
+    "print(f\"Neurodesktop version: {neurodesktop_version}\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  },
+  "rise": {
+   "scroll": true,
+   "start_slideshow_at": "selected"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a Neurodesk-style Jupyter notebook demonstrating a scripted first-level FEAT workflow using fMRIPrep outputs.

It includes:
- OpenNeuro/DataLad setup for one participant
- fMRIPrep preprocessing and confound extraction
- conversion of BIDS events.tsv files to FSL 3-column EV files
- rendering and running a first-level FEAT model from a template
- optional visualization of FEAT output with NiiVue

The notebook is intended as a novice-friendly example for the functional imaging section.