### PR TITLE
add FreeSurfer license to Demo_fmriprep_FEAT

### DIFF
--- a/books/examples/functional_imaging/Demo_fmriprep_FEAT.ipynb
+++ b/books/examples/functional_imaging/Demo_fmriprep_FEAT.ipynb
@@ -113,7 +113,7 @@
     "import module\n",
     "await module.load('fmriprep/25.2.5')\n",
     "await module.load('fsl/6.0.7.22')\n",
-    "await module.list()\n"
+    "await module.list()"
    ]
   },
   {
@@ -124,7 +124,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!pip install pandas\n"
+    "!pip install pandas"
    ]
   },
   {
@@ -141,7 +141,7 @@
     "from IPython.display import display, Markdown, Image\n",
     "\n",
     "base_dir = Path.home() / \"trust_example\"\n",
-    "print(base_dir)\n"
+    "print(base_dir)"
    ]
   },
   {
@@ -227,12 +227,14 @@
     "slideshow": {
      "slide_type": ""
     },
-    "tags": []
+    "tags": [
+     "scroll-output"
+    ]
    },
    "outputs": [],
    "source": [
     "!tree -L 3 ~/trust_example/templates\n",
-    "!tree -L 3 ~/trust_example/bids/ds003745/sub-104\n"
+    "!tree -L 3 ~/trust_example/bids/ds003745/sub-104"
    ]
   },
   {
@@ -263,7 +265,6 @@
     "A few practical notes:\n",
     "\n",
     "- the FreeSurfer license file should exist at `~/.license`\n",
-    "- we turn off BIDS validation here because this dataset is known to be BIDS-compatible, but the validator is causing trouble in this environment\n",
     "- this command will likely take **a couple of hours** to run\n",
     "- if you are wondering whether it is still running, go back to the **Terminal** and type `top`\n",
     "- the `antsRegistration` step is especially slow, so long stretches of apparent inactivity are normal\n",
@@ -275,11 +276,38 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c40fa02d",
-   "metadata": {},
+   "id": "70f0389d-f7b6-43d5-8e72-2c96ff14579b",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "!ls -l ~/.license\n"
+    "# Request a freesurfer license and store it in your homedirectory. \n",
+    "# This is just an example - please replace with your license id:\n",
+    "!echo \"Steffen.Bollmann@cai.uq.edu.au\" > ~/.license\n",
+    "!echo \"21029\" >> ~/.license\n",
+    "!echo \"*Cqyn12sqTCxo\" >> ~/.license\n",
+    "!echo \"FSxgcvGkNR59Y\" >> ~/.license"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c40fa02d",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!ls -l ~/.license"
    ]
   },
   {
@@ -335,7 +363,7 @@
     "  --nthreads 12 \\\n",
     "  --omp-nthreads 1 \\\n",
     "  --mem-mb 12000 \\\n",
-    "  -w \"$WORK_DIR\"\n"
+    "  -w \"$WORK_DIR\""
    ]
   },
   {
@@ -369,7 +397,7 @@
    "source": [
     "!find ~/trust_example/derivatives/fmriprep -name \"sub-104.html\"\n",
     "!find ~/trust_example/derivatives/fmriprep -name \"*run-01*desc-preproc_bold.nii.gz\"\n",
-    "!find ~/trust_example/derivatives/fmriprep -name \"*run-01*desc-confounds_timeseries.tsv\"\n"
+    "!find ~/trust_example/derivatives/fmriprep -name \"*run-01*desc-confounds_timeseries.tsv\""
    ]
   },
   {
@@ -469,18 +497,24 @@
     "mkdir -p \"$(dirname \"$out_base\")\"\n",
     "\n",
     "# This creates one 3-column file per event type found in the BIDS events file.\n",
-    "bash \"$EXAMPLE_DIR/bidsutils/BIDSto3col/BIDSto3col.sh\" \"$events_tsv\" \"$out_base\"\n"
+    "bash \"$EXAMPLE_DIR/bidsutils/BIDSto3col/BIDSto3col.sh\" \"$events_tsv\" \"$out_base\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "5d39cb13",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "!ls ~/trust_example/derivatives/fsl/EVfiles/sub-104/trust\n",
-    "!head -n 5 ~/trust_example/derivatives/fsl/EVfiles/sub-104/trust/run-01_choice_computer.txt\n"
+    "!head -n 5 ~/trust_example/derivatives/fsl/EVfiles/sub-104/trust/run-01_choice_computer.txt"
    ]
   },
   {
@@ -509,7 +543,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cae2365a",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "template_text = (base_dir / \"templates\" / \"L1_task-trust_model-01_type-act.fsf\").read_text()\n",
@@ -519,7 +559,7 @@
     "    for line in template_text.splitlines():\n",
     "        if token in line:\n",
     "            print(line)\n",
-    "    print()\n"
+    "    print()"
    ]
   },
   {
@@ -599,7 +639,7 @@
     "rendered_fsf = base_dir / \"derivatives\" / \"fsl\" / \"sub-104\" / \"L1_sub-104_task-trust_model-01_run-01_act.fsf\"\n",
     "print(rendered_fsf)\n",
     "print()\n",
-    "print(rendered_fsf.read_text()[:4000])\n"
+    "print(rendered_fsf.read_text()[:4000])"
    ]
   },
   {
@@ -624,14 +664,20 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "981c9aa2",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%bash\n",
     "set -e\n",
     "\n",
     "# Run FEAT on the rendered first-level design file.\n",
-    "feat \"$HOME/trust_example/derivatives/fsl/sub-104/L1_sub-104_task-trust_model-01_run-01_act.fsf\"\n"
+    "feat \"$HOME/trust_example/derivatives/fsl/sub-104/L1_sub-104_task-trust_model-01_run-01_act.fsf\""
    ]
   },
   {
@@ -653,7 +699,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6f917ce7",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%bash\n",
@@ -666,7 +718,7 @@
     "mkdir -p ${OUTPUT}.feat/reg\n",
     "ln -sf $FSLDIR/etc/flirtsch/ident.mat ${OUTPUT}.feat/reg/example_func2standard.mat\n",
     "ln -sf $FSLDIR/etc/flirtsch/ident.mat ${OUTPUT}.feat/reg/standard2example_func.mat\n",
-    "ln -sf ${OUTPUT}.feat/mean_func.nii.gz ${OUTPUT}.feat/reg/standard.nii.gz\n"
+    "ln -sf ${OUTPUT}.feat/mean_func.nii.gz ${OUTPUT}.feat/reg/standard.nii.gz"
    ]
   },
   {
@@ -693,7 +745,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cd5d764b",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "feat_dir = base_dir / \"derivatives\" / \"fsl\" / \"sub-104\" / \"L1_task-trust_model-01_type-act_run-01_sm-6.feat\"\n",
@@ -706,21 +764,27 @@
     "    \"thresh_zstat10.nii.gz\",\n",
     "]:\n",
     "    p = feat_dir / rel\n",
-    "    print(f\"{p}: {p.exists()}\")\n"
+    "    print(f\"{p}: {p.exists()}\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "9482aa0c",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "design_png = feat_dir / \"design.png\"\n",
     "if design_png.exists():\n",
     "    display(Image(filename=str(design_png)))\n",
     "else:\n",
-    "    print(\"Run FEAT first, then come back to this cell.\")\n"
+    "    print(\"Run FEAT first, then come back to this cell.\")"
    ]
   },
   {
@@ -746,7 +810,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1c12c5e9",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
@@ -790,7 +860,7 @@
     "    ])\n",
     "    display(nv)\n",
     "else:\n",
-    "    print(\"Run FEAT first, then come back to this cell.\")\n"
+    "    print(\"Run FEAT first, then come back to this cell.\")"
    ]
   },
   {
@@ -798,15 +868,21 @@
    "id": "ce7f5748",
    "metadata": {},
    "source": [
-    "## 10. Dependencies in Jupyter/Python\n",
-    "- Using the package [watermark](https://github.com/rasbt/watermark) to document system environment and software versions used in this notebook, alongside the Neurodesktop version extracted from the `JUPYTER_IMAGE` environment variable.\n"
+    "#### Dependencies in Jupyter/Python\n",
+    "- Using the package [watermark](https://github.com/rasbt/watermark) to document system environment and software versions used in this notebook, alongside the Neurodesktop version extracted from the `JUPYTER_IMAGE` or `NEURODESKTOP_VERSION` environment variables."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "24b30dc8",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -816,17 +892,13 @@
     "%watermark\n",
     "%watermark --iversions\n",
     "\n",
-    "neurodesktop_version = os.environ.get('JUPYTER_IMAGE', 'unknown').split(':')[-1]\n",
-    "print(f\"Neurodesktop version: {neurodesktop_version}\")\n"
+    "neurodesktop_version = (\n",
+    "    os.environ.get('JUPYTER_IMAGE', '').split(':')[-1] or\n",
+    "    os.environ.get('NEURODESKTOP_VERSION', 'unknown')\n",
+    ")\n",
+    "\n",
+    "print(f\"Neurodesktop version: {neurodesktop_version}\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "777d7410-f86e-4da6-a76a-71df8f09d5ae",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -845,7 +917,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.11"
   },
   "rise": {
    "scroll": true,


### PR DESCRIPTION
@DVSneuro I added a FreeSurfer license cell to the notebook — CI was failing because ~/.license didn't exist in the runner environment, which caused fMRIPrep to exit immediately and cascade into all downstream cells. I also removed the sentence about turning off BIDS validation ("we turn off BIDS validation here because this dataset is known to be BIDS-compatible, but the validator is causing trouble in this environment").  