### PR TITLE
Fix fsl_all_levels_flanker_nipype on slim image (nipype numpy-2.x patch)

### DIFF
--- a/books/examples/functional_imaging/fsl_all_levels_flanker_nipype.ipynb
+++ b/books/examples/functional_imaging/fsl_all_levels_flanker_nipype.ipynb
@@ -159,15 +159,17 @@
    },
    "outputs": [],
    "source": [
-    "#%%capture\n",
-    "# numpy is pinned to 1.26.4 due to a nipype/numpy 2.x incompatibility in\n",
-    "# nipype's L2Model (fsl/model.py) - TypeError on scalar conversion under numpy>=2.0\n",
-    "#\n",
-    "# numpy 1.26.4 has no prebuilt wheel for Python 3.13, so it must be built\n",
-    "# from source - this requires a C/Fortran compiler, which the base image\n",
-    "# does not include by default.\n",
-    "!sudo apt-get update && sudo apt-get install -y build-essential gfortran\n",
-    "!pip install numpy==1.26.4 pandas==2.3.3 nibabel==5.3.3 nilearn==0.13.1 nipype==1.11.0"
+    "# nipype 1.11.0's MultipleRegressDesign formats (N,1) numpy arrays with %e/%d,\n",
+    "# which numpy>=2 rejects (\"only 0-dimensional arrays can be converted to Python\n",
+    "# scalars\"). There is no numpy<2 wheel for Python 3.13, so rather than downgrade\n",
+    "# numpy (a slow source build), keep numpy 2.x and fix the two affected lines.\n",
+    "import sys, subprocess, glob, pathlib\n",
+    "subprocess.run([sys.executable, \"-m\", \"pip\", \"install\",\n",
+    "                \"pandas==2.3.3\", \"nibabel==5.3.3\", \"nilearn==0.13.1\", \"nipype==1.11.0\"],\n",
+    "               check=False)\n",
+    "for _m in map(pathlib.Path, glob.glob(f\"{sys.prefix}/lib/python*/site-packages/nipype/interfaces/fsl/model.py\")):\n",
+    "    _m.write_text(_m.read_text().replace(\"val for val in convals\", \"val for val in convals.ravel()\"))\n",
+    "    print(\"Patched nipype MultipleRegressDesign for numpy>=2:\", _m)"
    ]
   },
   {


### PR DESCRIPTION
## Summary
Makes `fsl_all_levels_flanker_nipype` pass on the slim CI image (`neurocommand:py-stack`, Python 3.13 / numpy 2.x). It fixes the nipype/numpy 2.x incompatibility directly instead of downgrading numpy.

## What was failing
1. The notebook hung forever on the `!sudo apt-get install build-essential gfortran` cell. `jovyan` has no passwordless sudo in the CI container, so `sudo` blocked on a password prompt with no TTY. (It worked interactively on Neurodesk Play, which grants passwordless sudo.)
2. Those build tools only existed to compile `numpy==1.26.4`, pinned to avoid a nipype/numpy 2.x bug. `numpy 1.26.4` has no Python 3.13 wheel, so it had to build from source on every run, which is slow and fragile.

## The fix
Keep the image's numpy 2.x and patch the nipype bug. `MultipleRegressDesign._run_interface` formats `(N,1)` numpy arrays with `%e`/`%d` (lines 1553 and 1569), which numpy 2.x rejects with a TypeError. Iterating `convals.ravel()` yields 0-d scalars again, with value-identical output.

The old apt-get and `numpy==1.26.4` cell becomes:
```python
import sys, subprocess, glob, pathlib
subprocess.run([sys.executable, "-m", "pip", "install",
                "pandas==2.3.3", "nibabel==5.3.3", "nilearn==0.13.1", "nipype==1.11.0"],
               check=False)
for _m in map(pathlib.Path, glob.glob(f"{sys.prefix}/lib/python*/site-packages/nipype/interfaces/fsl/model.py")):
    _m.write_text(_m.read_text().replace("val for val in convals", "val for val in convals.ravel()"))
    print("Patched nipype MultipleRegressDesign for numpy>=2:", _m)
```

## Validation
Green on `neurocommand:py-stack` (Python 3.13, numpy 2.4.6): notebook job success, "No errors found in notebook outputs", l2model TypeError gone, full 3-level analysis in ~17 min, no hang.

## Notes
The patch edits nipype on disk, so the cell must run before any nipype FSL interface is imported (it does). Worth reporting upstream to nipype so a future release fixes it and this patch can be dropped.
