### PR TITLE
Switch CI to the full neurodesktop image (lean nbconvert run)

### DIFF
--- a/.github/workflows/run_and_publish_notebooks.yml
+++ b/.github/workflows/run_and_publish_notebooks.yml
@@ -147,12 +147,14 @@ jobs:
           if [ -n "${{ inputs.image_override }}" ]; then
             echo "neurodesk_image=${{ inputs.image_override }}" >> $GITHUB_OUTPUT
           else
-            # Production default: slim py-stack (validated 2026-06-08, replaces full neurodesktop).
-            # Frozen tag maintained by the image team; image_override still works for one-offs.
-            # Previous full-image default kept for one-line revert:
-            #   NEURODESKTOP_VERSION=$(curl -s https://raw.githubusercontent.com/neurodesk/neurodesk.github.io/main/data/neurodesktop.toml | grep '^jupyter_neurodesk_version' | sed 's/.*= *"\(.*\)"/\1/')
-            #   echo "neurodesk_image=ghcr.io/neurodesk/neurodesktop/neurodesktop:${NEURODESKTOP_VERSION}" >> $GITHUB_OUTPUT
-            echo "neurodesk_image=ghcr.io/neurodesk/neurocommand:py-stack" >> $GITHUB_OUTPUT
+            # Production default: full neurodesktop image, so CI runs the SAME environment
+            # Neurodesk users run (and catches the same errors). Executed via lean nbconvert
+            # (no Jupyter server, via the `sleep infinity` CMD override below). image_override
+            # still works for one-offs, e.g. slim py-stack benchmarking.
+            NEURODESKTOP_VERSION=$(curl -s https://raw.githubusercontent.com/neurodesk/neurodesk.github.io/main/data/neurodesktop.toml | grep '^jupyter_neurodesk_version' | sed 's/.*= *"\(.*\)"/\1/')
+            echo "neurodesk_image=ghcr.io/neurodesk/neurodesktop/neurodesktop:${NEURODESKTOP_VERSION}" >> $GITHUB_OUTPUT
+            # Slim py-stack default kept for one-line revert:
+            #   echo "neurodesk_image=ghcr.io/neurodesk/neurocommand:py-stack" >> $GITHUB_OUTPUT
           fi
           echo "Using image: $(grep neurodesk_image $GITHUB_OUTPUT | cut -d= -f2)"
 
@@ -538,7 +540,13 @@ jobs:
           echo "Waiting for Neurodesktop to become ready (up to 5 minutes)..."
           for i in {1..300}; do
             if docker logs "$CONTAINER_NAME" 2>&1 | grep -qE "To access the server|\[neurocommand\] CVMFS"; then
-              echo "Container ready after ${i} seconds"
+              echo "Container ready (startup log) after ${i} seconds"
+              exit 0
+            fi
+            # Image-agnostic fallback: ready once CVMFS modules are visible inside the container
+            # (full neurodesktop under `sleep infinity` may not print the slim image's log line).
+            if docker exec "$CONTAINER_NAME" test -d /cvmfs/neurodesk.ardc.edu.au/containers/modules 2>/dev/null; then
+              echo "Container ready (CVMFS mounted) after ${i} seconds"
               exit 0
             fi
             sleep 1
@@ -1859,7 +1867,13 @@ jobs:
           echo "Waiting for Neurodesktop to become ready (up to 5 minutes)..."
           for i in {1..300}; do
             if docker logs "$CONTAINER_NAME" 2>&1 | grep -qE "To access the server|\[neurocommand\] CVMFS"; then
-              echo "Container ready after ${i} seconds"
+              echo "Container ready (startup log) after ${i} seconds"
+              exit 0
+            fi
+            # Image-agnostic fallback: ready once CVMFS modules are visible inside the container
+            # (full neurodesktop under `sleep infinity` may not print the slim image's log line).
+            if docker exec "$CONTAINER_NAME" test -d /cvmfs/neurodesk.ardc.edu.au/containers/modules 2>/dev/null; then
+              echo "Container ready (CVMFS mounted) after ${i} seconds"
               exit 0
             fi
             sleep 1


### PR DESCRIPTION
## Summary
Switches the default CI image from the slim `neurocommand:py-stack` back to the full `neurodesktop` image, so CI runs the same environment Neurodesk users run. Notebooks still execute via lean nbconvert (no Jupyter server), so the run method is unchanged.

## Why
On the slim image, CI could pass or fail for reasons users never see, and contributors got confused when a notebook ran on their Neurodesk instance but broke in CI. The full image makes CI match the user environment and also exercises the neurodesktop image itself. The slim speed/size win was not worth the recurring "fix a missing dependency every time" maintenance and the false confidence.

## What changes
- Default flips to full neurodesktop, resolved dynamically from the `neurodesktop.toml` version (currently 2026-06-04). The slim line is kept as a one-line revert.
- `image_override` still works, so slim is one dispatch away for benchmarking.
- The container-readiness check gains a CVMFS-mounted fallback, so it is robust regardless of the image's startup log line.

## Validation
Ran the full ~55-notebook corpus on the full image (lean run): image pull, container start, readiness, CVMFS, and notebook execution all work. Notebook content passes; the only failures were cluster CVMFS flakes under the load of 55 concurrent big-image pulls, which does not happen in normal CI (only the changed notebooks run). A full side-by-side scorecard vs slim will follow off-hours.
