### PR TITLE
Fix brain_extraction: drop hd-bet bind that hid baked model weights

### DIFF
--- a/books/examples/structural_imaging/brain_extraction_different_tools.ipynb
+++ b/books/examples/structural_imaging/brain_extraction_different_tools.ipynb
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -217,18 +217,7 @@
     "tags": []
    },
    "outputs": [],
-   "source": [
-    "# HD-BET downloads ~400 MB of weights to /opt/HD-BET/hd-bet_params on first run,\n",
-    "# which is read-only inside the container. Bind a writable host cache dir there\n",
-    "# so the download succeeds and is reused across sessions.\n",
-    "hdbet_cache = pathlib.Path.home() / \".cache\" / \"hd-bet\"\n",
-    "hdbet_cache.mkdir(parents=True, exist_ok=True)\n",
-    "existing = os.environ.get(\"neurodesk_singularity_opts\", \"\")\n",
-    "os.environ[\"neurodesk_singularity_opts\"] = f\"{existing} --bind {hdbet_cache}:/opt/HD-BET/hd-bet_params\".strip()\n",
-    "\n",
-    "import module\n",
-    "await module.load('hdbet/2.0.1')"
-   ]
+   "source": "# hdbet/2.0.1 ships its model weights baked into the container at\n# /opt/HD-BET/hd-bet_params, so no download or bind mount is needed. Bind-mounting a\n# writable cache over that path hides the baked weights and forces a re-download that\n# fails on the read-only container filesystem in CI.\nimport module\nawait module.load('hdbet/2.0.1')"
   },
   {
    "cell_type": "markdown",

--- a/books/examples/structural_imaging/brain_extraction_different_tools.ipynb
+++ b/books/examples/structural_imaging/brain_extraction_different_tools.ipynb
@@ -217,7 +217,7 @@
     "tags": []
    },
    "outputs": [],
-   "source": "# hdbet/2.0.1 ships its model weights baked into the container at\n# /opt/HD-BET/hd-bet_params, so no download or bind mount is needed. Bind-mounting a\n# writable cache over that path hides the baked weights and forces a re-download that\n# fails on the read-only container filesystem in CI.\nimport module\nawait module.load('hdbet/2.0.1')"
+   "source": "# hdbet/2.0.1 ships its model weights baked into the container at\n# /opt/HD-BET/hd-bet_params, so no download or bind mount is needed. \n\nimport module\nawait module.load('hdbet/2.0.1')"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
### Problem
On the full neurodesktop image, `brain_extraction_different_tools` fails in CI. Cell 9 bind mounts an empty writable cache onto `/opt/HD-BET/hd-bet_params`. That hides the model weights baked into the `hdbet/2.0.1` container and forces HD-BET to re-download them into a read-only path, which fails with `OSError errno 30`.

### Fix
Remove the bind mount and load hdbet via `module load`. The weights already ship in the container, so no download is needed.

### Test
Single notebook CI run on this branch passed green (run 27895889215).

### Review note
Please confirm your Lab session loads `hdbet/2.0.1`. There is no download fallback if that module is missing.
