### PR TITLE
Add monthly scheduled corpus drift check (separate workflow)

### DIFF
--- a/.github/workflows/run_and_publish_notebooks.yml
+++ b/.github/workflows/run_and_publish_notebooks.yml
@@ -67,6 +67,15 @@ on:
         type: boolean
         default: false
 
+  # Called by scheduled-drift-check.yml for the monthly drift health check.
+  workflow_call:
+    inputs:
+      drift_check:
+        description: 'Drift-check mode: force all notebooks, skip the HF cache-promote, and do no side effects (HF/Zenodo/Pages).'
+        required: false
+        type: boolean
+        default: false
+
 # =============================================================================
 # CONCURRENCY (disabled to allow multiple runs)
 # =============================================================================
@@ -198,8 +207,8 @@ jobs:
         id: list_notebooks
         run: |
           # Determine which notebooks to run based on trigger type
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "Mode: Scheduled run, execute ALL notebooks"
+          if [ "${{ inputs.drift_check }}" = "true" ]; then
+            echo "Mode: Drift check, execute ALL notebooks"
             changed_notebooks=$(find books -name "*.ipynb" | sed 's|^books/||')
 
           elif [ "${{ inputs.force_execution }}" == "true" ]; then
@@ -714,7 +723,9 @@ jobs:
           echo "Saved source snapshot: $SOURCE_DIR/$(basename "$NOTEBOOK_PATH")"
 
       - name: Try promoting cached notebook (main only)
-        if: github.ref == 'refs/heads/main'
+        # Skip on drift checks: re-execute for real to catch upstream drift,
+        # not a cache hit that would mask it.
+        if: github.ref == 'refs/heads/main' && inputs.drift_check != true
         id: promote
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -951,7 +962,7 @@ jobs:
       # 2. Transform uploads data to HF, rewrites paths->urls, clears outputs
       # 3. Second execution generates clean outputs with HF URLs
       - name: Transform notebook paths to HF URLs (post-execution)
-        if: steps.promote.outputs.promoted != 'true' && inputs.diagnostic_mode != true
+        if: steps.promote.outputs.promoted != 'true' && inputs.diagnostic_mode != true && inputs.drift_check != true
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_REPO: neurodeskorg/neurodeskedu
@@ -1223,7 +1234,7 @@ jobs:
           retention-days: 7
 
       - name: Upload source + executed notebooks to HuggingFace
-        if: success() && inputs.diagnostic_mode != true
+        if: success() && inputs.diagnostic_mode != true && inputs.drift_check != true
         # ARC pods see ~2% transient HF network failures (cluster team-confirmed infra floor).
         # Without this gate, one transient would fail the run-notebooks job and block publish-pages
         # entirely — 49 successful notebooks would not deploy because of one failed upload.
@@ -1408,7 +1419,7 @@ jobs:
   publish-dois:
     name: Publish DOIs to Zenodo
     needs: [run-notebooks]
-    if: ${{ needs.run-notebooks.result == 'success' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.run-notebooks.result == 'success' && github.ref == 'refs/heads/main' && inputs.drift_check != true }}
     runs-on: ubuntu-22.04
     concurrency:
       group: publish-dois
@@ -1559,7 +1570,7 @@ jobs:
   publish-pages:
     name: Build & Publish to GitHub Pages
     needs: [run-notebooks, setup, publish-dois]
-    if: ${{ always() && (needs.run-notebooks.result == 'success' || needs.run-notebooks.result == 'skipped' || needs.run-notebooks.result == 'failure') }}
+    if: ${{ always() && inputs.drift_check != true && (needs.run-notebooks.result == 'success' || needs.run-notebooks.result == 'skipped' || needs.run-notebooks.result == 'failure') }}
     runs-on: ubuntu-22.04
     # Serialize publish jobs to prevent race conditions on gh-pages
     concurrency:

--- a/.github/workflows/scheduled-drift-check.yml
+++ b/.github/workflows/scheduled-drift-check.yml
@@ -1,0 +1,110 @@
+# =============================================================================
+# Scheduled corpus drift check
+# =============================================================================
+# Monthly health check: re-runs the full notebook corpus on a schedule to catch
+# upstream package or image drift (e.g. a new package version breaking a
+# notebook), and opens a GitHub issue listing anything that fails.
+#
+# It reuses the corpus pipeline in run_and_publish_notebooks.yml via
+# workflow_call (drift_check: true), which forces all notebooks, skips the
+# HuggingFace cache-promote so it really re-executes, and does no side effects
+# (no HuggingFace upload, no Zenodo DOIs, no Pages deploy).
+# =============================================================================
+
+name: Scheduled corpus drift check
+
+on:
+  schedule:
+    # GitHub cron is UTC and cannot express "first Saturday", so this fires every
+    # Saturday 14:00 UTC (Sunday 00:00 Brisbane / AEST) and the guard job below
+    # runs the corpus only on the first Saturday of the month.
+    - cron: '0 14 * * 6'
+
+jobs:
+  # 1. First-Saturday guard: the cron fires weekly; run the corpus only on the
+  #    first Saturday of the month so the cadence is effectively monthly.
+  guard:
+    name: First-Saturday guard
+    runs-on: ubuntu-22.04
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - id: check
+        run: |
+          if [ "$(date -u +%-d)" -le 7 ]; then
+            echo "First Saturday of the month; running the corpus."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Not the first Saturday; skipping (monthly cadence)."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # 2. Run the full corpus via the reusable workflow, in drift-check mode
+  #    (force all, no cache-promote, no side effects).
+  corpus:
+    name: Corpus
+    needs: guard
+    if: ${{ needs.guard.outputs.run == 'true' }}
+    uses: ./.github/workflows/run_and_publish_notebooks.yml
+    with:
+      drift_check: true
+    secrets: inherit
+
+  # 3. If anything failed, open or update a single rolling corpus-drift issue.
+  report:
+    name: Report drift
+    needs: [guard, corpus]
+    if: ${{ always() && needs.guard.outputs.run == 'true' && needs.corpus.result == 'failure' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      issues: write
+      actions: read
+    steps:
+      - name: Open or update the corpus-drift issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            const label = 'corpus-drift';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const today = new Date().toISOString().slice(0, 10);
+
+            // Ensure the label exists (no-op if it already does).
+            try {
+              await github.rest.issues.createLabel({ owner, repo, name: label, color: 'B60205', description: 'Scheduled corpus run found drift' });
+            } catch (e) { /* already exists */ }
+
+            // Collect the notebooks that failed in this run. Reusable-workflow jobs
+            // are named "Corpus / Run Notebook (<path>)", so match anywhere in the name.
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner, repo, run_id: context.runId, per_page: 100,
+            });
+            const failed = jobs
+              .filter(j => j.conclusion === 'failure' && j.name.includes('Run Notebook ('))
+              .map(j => (j.name.match(/Run Notebook \((.+)\)/) || [null, j.name])[1])
+              .sort();
+            const list = failed.length
+              ? failed.map(n => `- \`${n}\``).join('\n')
+              : '- (failure outside a notebook job, see the run log)';
+            const body = [
+              `The scheduled monthly corpus run on **${today}** found **${failed.length}** failing notebook(s):`,
+              '', list, '',
+              `Run: ${runUrl}`, '',
+              `These are usually upstream package or image drift. Investigate each, pin a known-good version, and re-run.`,
+            ].join('\n');
+            const title = 'Scheduled corpus drift: notebook(s) failing';
+
+            // Reuse one rolling open issue to avoid inbox spam.
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', labels: label, per_page: 100,
+            });
+            if (existing.length) {
+              const num = existing[0].number;
+              await github.rest.issues.update({ owner, repo, issue_number: num, body });
+              await github.rest.issues.createComment({ owner, repo, issue_number: num, body: `Re-checked **${today}**: ${failed.length} failing. ${runUrl}` });
+              core.notice(`Updated drift issue #${num}`);
+            } else {
+              const created = await github.rest.issues.create({ owner, repo, title, body, labels: [label] });
+              core.notice(`Opened drift issue #${created.data.number}`);
+            }


### PR DESCRIPTION
## Why
Notebooks silently break from upstream package or image drift (most recently
ggseg 2.2.0 breaking the R tutorial). Nothing re-runs the full corpus between
pushes, so drift sits undetected until someone notices. This adds a scheduled
full-corpus run that catches drift early and files an issue.

## How it is structured
The drift-check is self-contained in `scheduled-drift-check.yml` and reuses the
existing corpus pipeline instead of duplicating it:
- A `schedule` cron (first Saturday of each month, 14:00 UTC, overnight Sunday
  AEST) plus a first-Saturday guard.
- It calls `run_and_publish_notebooks.yml` via `workflow_call` with
  `drift_check: true`, which forces all notebooks, skips the HF cache-promote so
  it genuinely re-runs, and does no side effects (no HF upload, no Zenodo, no
  Pages deploy).
- If anything fails, a `report` job opens or updates a single rolling issue
  labeled `corpus-drift` listing the failed notebooks and run link. A green run
  files nothing.

The change to `run_and_publish_notebooks.yml` is minimal (+18/-7): a
`workflow_call` trigger plus a few one-line `drift_check` gates. Normal push and
workflow_dispatch behaviour is unchanged.

## Note
The cron fires every Saturday but only the first Saturday of the month runs the
corpus; the others are a ~1 minute no-op (the guard job).

Supersedes #126 (got stuck closed after a force-push).
