### PR TITLE
Add callr/ps install to fix ggsegSchaefer GitHub fallback

### DIFF
--- a/books/_toc.yml
+++ b/books/_toc.yml
@@ -10,6 +10,8 @@ chapters:
           - file: examples/diffusion_imaging/MRtrix_2
           - file: examples/diffusion_imaging/MRtrix_3
           - file: examples/diffusion_imaging/mrtrix3tissue
+          - file: examples/diffusion_imaging/qsiprep
+          - file: examples/diffusion_imaging/qsirecon
 
       - file: examples/electrophysiology/intro
         sections:


### PR DESCRIPTION
remotes::install_github() requires callr to build packages in an isolated subprocess. r-universe is unreachable in this environment, so ggsegSchaefer falls back to GitHub install, which failed with "there is no package called 'callr'". Install callr (and its ps dependency) from CRAN before the fallback runs.

## Notebook submission checklist

Thank you for contributing to NeurodeskEDU! Please confirm the following before requesting a review.

### Notebook quality

- [x] I started from the [`template.ipynb`](https://github.com/neurodesk/neurodeskedu) and kept the standard metadata, `watermark`, and `module load` sections.
- [x] I restarted the kernel and ran all cells from top to bottom without errors before submitting.
- [x] My notebook uses an openly available dataset and cites it with a DOI or permanent link.
- [x] I have read the [Design Principles](https://github.com/neurodesk/neurodeskedu#design-principles) and my notebook follows them.

### Terms of submission

- [x] **I have read and agree to the [Terms of Submission](https://github.com/neurodesk/neurodeskedu/blob/main/TERMS_OF_SUBMISSION.md).** In particular, I understand that:
  - a peer review will be initiated after publication (publication is not delayed by the review);
  - a review-status badge will appear on my notebook;
  - I am expected to respond to reviewer comments within ~15 days;
  - Neurodesk may make maintenance edits to keep the notebook functional and conformant; and
  - if I do not respond to reviewers, Neurodesk may create a successor notebook citing mine as the starting point.

