### PR TITLE
ci: harden review-branch workflow and enforce diagnostic_mode

### DIFF
--- a/.github/workflows/create_review_branch.yml
+++ b/.github/workflows/create_review_branch.yml
@@ -26,9 +26,11 @@ jobs:
       - name: Create review branch and post instructions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PR-controlled values are passed via env (not interpolated into the
+          # run: script) so a crafted fork branch name cannot inject shell.
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
         run: |
-          PR_NUM=${{ github.event.pull_request.number }}
-          PR_HEAD=${{ github.event.pull_request.head.ref }}
           BRANCH="review/pr-${PR_NUM}"
 
           # Check if review branch already exists

--- a/.github/workflows/run_and_publish_notebooks.yml
+++ b/.github/workflows/run_and_publish_notebooks.yml
@@ -1419,7 +1419,7 @@ jobs:
   publish-dois:
     name: Publish DOIs to Zenodo
     needs: [run-notebooks]
-    if: ${{ needs.run-notebooks.result == 'success' && github.ref == 'refs/heads/main' && inputs.drift_check != true }}
+    if: ${{ needs.run-notebooks.result == 'success' && github.ref == 'refs/heads/main' && inputs.drift_check != true && inputs.diagnostic_mode != true }}
     runs-on: ubuntu-22.04
     concurrency:
       group: publish-dois
@@ -2140,7 +2140,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-        if: github.ref == 'refs/heads/main' || inputs.force_deploy_pages == true
+        if: (github.ref == 'refs/heads/main' || inputs.force_deploy_pages == true) && inputs.diagnostic_mode != true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./books/_build/html


### PR DESCRIPTION
Two low-risk CI hardening fixes from the workflow review.

H1 — create_review_branch.yml (security)
This workflow runs on pull_request_target (privileged token) and interpolated
the PR branch name straight into the run: shell block. A crafted fork branch
name could inject shell. Moved the PR number and head ref into the step env:
block so they're passed as plain variables, never evaluated as code. No change
for legitimate PRs.

M1 — run_and_publish_notebooks.yml (correctness)
diagnostic_mode is meant to have zero external side effects, but two steps only
gated on the branch being main:
  - publish-dois (Zenodo) could still mint DOIs
  - Deploy to GitHub Pages could still publish the live site
Added `&& inputs.diagnostic_mode != true` to both so a diagnostic run on main
is truly side-effect-free.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow safety when processing pull request branch names.
  * Diagnostic runs no longer publish DOIs or deploy documentation to GitHub Pages, preventing unintended releases during troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->