### PR TITLE
fix: extract notebook author from the whole header, not just cell 0

### DIFF
--- a/.github/scripts/notebook_metadata.py
+++ b/.github/scripts/notebook_metadata.py
@@ -8,7 +8,11 @@ import re
 from typing import List
 
 
-_AUTHOR_LINE_RE = re.compile(r"^authors?\s*:?[\s\-]*(.*)$", re.IGNORECASE)
+# Require a ':' after the label. Without it, a sentence line such as the template's
+# "Author of this template : ..." instruction is mistaken for an author field. The
+# markdown and front-matter paths below already require the colon; this aligns the
+# notebook path with them.
+_AUTHOR_LINE_RE = re.compile(r"^authors?\s*:\s*(.*)$", re.IGNORECASE)
 _STOP_LINE_RE = re.compile(
     r"^(date|title|license|doi|institution|affiliation|contact|email|version)\b",
     re.IGNORECASE,
@@ -105,17 +109,34 @@ def extract_authors_from_first_cell_source(first_cell_source: str) -> List[str]:
 
 
 def extract_authors_from_notebook(notebook_obj: dict) -> List[str]:
-    """Extract author names from the first notebook cell."""
-    first_cell_source = ""
-    cells = notebook_obj.get("cells", [])
-    if cells:
-        source = cells[0].get("source", [])
-        first_cell_source = "".join(source) if isinstance(source, list) else str(source)
-    return extract_authors_from_first_cell_source(first_cell_source)
+    """Extract author names from the notebook's leading markdown header.
+
+    The project template puts the title in the first cell and the "**Author**:"
+    line in a *later* markdown cell, so scanning only cells[0] misses the author
+    and the publisher falls back to a generic creator. Scan the contiguous
+    markdown header block instead and return the first hit.
+
+    The scan stops at the first code cell — author metadata always lives in the
+    header, so stopping there avoids picking up stray "Author:" mentions in later
+    citation/reference prose. Non-code, non-markdown cells (e.g. leading raw
+    cells) are skipped rather than treated as the boundary.
+    """
+    for cell in notebook_obj.get("cells", []):
+        cell_type = cell.get("cell_type")
+        if cell_type == "code":
+            break
+        if cell_type != "markdown":
+            continue
+        source = cell.get("source", [])
+        cell_source = "".join(source) if isinstance(source, list) else str(source)
+        authors = extract_authors_from_first_cell_source(cell_source)
+        if authors:
+            return authors
+    return []
 
 
 def extract_authors_from_first_cell(notebook_path: str) -> List[str]:
-    """Load a notebook and return author names from the first cell."""
+    """Load a notebook and return author names from its leading markdown header."""
     with open(notebook_path, "r", encoding="utf-8") as fh:
         notebook_obj = json.load(fh)
     return extract_authors_from_notebook(notebook_obj)

--- a/.github/scripts/test_notebook_metadata.py
+++ b/.github/scripts/test_notebook_metadata.py
@@ -49,6 +49,13 @@ def test_template_decoy_line_is_not_matched():
     assert extract_authors_from_first_cell_source(src) == []
 
 
+def test_author_label_requires_colon():
+    # The colon is what separates an author field from prose. Without it nothing
+    # is extracted — this pins the label regex so it can't be loosened silently.
+    assert extract_authors_from_first_cell_source("**Author** Jane Doe\n") == []
+    assert extract_authors_from_first_cell_source("Authors - Jane Doe\n") == []
+
+
 def test_multiple_authors_split():
     nb = _md("# Title\n", "**Author**: Ada Lovelace and Alan Turing\n")
     assert extract_authors_from_notebook(nb) == ["Ada Lovelace", "Alan Turing"]

--- a/.github/scripts/test_notebook_metadata.py
+++ b/.github/scripts/test_notebook_metadata.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Tests for author extraction, focused on the cell-scan / label-match behaviour.
+
+Run: python .github/scripts/test_notebook_metadata.py   (or via pytest)
+
+Regression context: the extractor originally read only cells[0]. Notebooks that
+follow the project template put the title in cells[0] and the "**Author**:" line
+in a later markdown cell, so their author was silently dropped and the Zenodo
+publisher fell back to the generic "Neurodesk Project" creator.
+"""
+
+from notebook_metadata import (
+    extract_authors_from_notebook,
+    extract_authors_from_first_cell_source,
+)
+
+
+def _md(*sources):
+    return {"cells": [{"cell_type": "markdown", "source": s} for s in sources]}
+
+
+def test_author_in_first_cell_still_works():
+    nb = _md("# Title\n\n**Author**: Jane Doe\n")
+    assert extract_authors_from_notebook(nb) == ["Jane Doe"]
+
+
+def test_author_in_second_cell_template_layout():
+    # Title and author in separate cells — the layout that used to be dropped.
+    nb = _md("# Scripted First-Level Analyses\n", "**Author**: John Smith\n")
+    assert extract_authors_from_notebook(nb) == ["John Smith"]
+
+
+def test_author_inside_html_orcid_markup():
+    # Mirrors the real Demo_fmriprep_FEAT header: label on one line, name wrapped
+    # in an ORCID <a>/<i> block on the next.
+    cell = (
+        '**Author**: <div style="margin-top: 10px;">\n'
+        '    <a href="https://orcid.org/0000-0001-5754-9633" target="_blank">\n'
+        '        <i class="fab fa-orcid"></i> David V. Smith\n'
+        "    </a>\n"
+        "</div>\n"
+    )
+    assert extract_authors_from_notebook(_md("# Title\n", cell)) == ["David V. Smith"]
+
+
+def test_template_decoy_line_is_not_matched():
+    # "Author of this template : X" is an instruction sentence, not an author field.
+    src = "**Author of this template** : Someone Example [Remove this line]\n"
+    assert extract_authors_from_first_cell_source(src) == []
+
+
+def test_multiple_authors_split():
+    nb = _md("# Title\n", "**Author**: Ada Lovelace and Alan Turing\n")
+    assert extract_authors_from_notebook(nb) == ["Ada Lovelace", "Alan Turing"]
+
+
+def test_scan_stops_at_first_code_cell():
+    # An "Author:" that only appears after code (e.g. in prose) must not be picked up.
+    nb = {
+        "cells": [
+            {"cell_type": "markdown", "source": "# Title only\n"},
+            {"cell_type": "code", "source": "print('hi')\n"},
+            {"cell_type": "markdown", "source": "**Author**: Too Late\n"},
+        ]
+    }
+    assert extract_authors_from_notebook(nb) == []
+
+
+def test_leading_raw_cell_is_skipped_not_boundary():
+    nb = {
+        "cells": [
+            {"cell_type": "raw", "source": "---\nrise config\n---\n"},
+            {"cell_type": "markdown", "source": "# Title\n"},
+            {"cell_type": "markdown", "source": "**Author**: Grace Hopper\n"},
+        ]
+    }
+    assert extract_authors_from_notebook(nb) == ["Grace Hopper"]
+
+
+def test_no_author_returns_empty():
+    nb = _md("# Just a title\n", "Some description with no author line.\n")
+    assert extract_authors_from_notebook(nb) == []
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"FAIL {t.__name__}: {exc}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    raise SystemExit(1 if failed else 0)

--- a/.github/skip-notebooks.txt
+++ b/.github/skip-notebooks.txt
@@ -1,3 +1,8 @@
 # Notebooks to skip in CI execution
 # One notebook path per line (relative to books/ directory)
 # Lines starting with # are comments
+
+# Scaffolding, not real educational content: skipping execution also keeps it out
+# of the executed-artifacts set, so it is not minted a Zenodo DOI. (Its author cell
+# holds placeholder text, which would otherwise be published as a bogus creator.)
+examples/template.ipynb


### PR DESCRIPTION
## Problem
Notebooks published to Zenodo were credited to "Neurodesk Project" instead of
their real author (e.g. `Demo_fmriprep_FEAT` → David V. Smith). 12 published
DOIs are affected.

## Cause
`extract_authors_from_notebook` read only `cells[0]`. Notebooks that follow the
template put the title in the first cell and `**Author**:` in a *separate* later
markdown cell, so the author was never seen and the publisher hit its
"Neurodesk Project" fallback — silently, with no error. Notebooks that keep
title + author in the same first cell were unaffected (why most work).

## Fix (this PR — 3 files, all permanent)
- Scan the contiguous markdown header (stop at the first code cell) instead of
  only `cells[0]`.
- Require a colon after the `Author` label so the template's decoy
  "Author of this template :" instruction line isn't matched.
- Add `test_notebook_metadata.py` (first-cell, second-cell, ORCID/HTML markup,
  decoy, stop-at-code, multi-author).
- Skip `template.ipynb` from publishing — scaffolding shouldn't get a DOI.

Verified over all 57 notebooks: 57/57 resolve, **0 regressions** (44 unchanged,
13 recovered). Unit tests 8/8 pass.

## Correcting the 12 already-published DOIs (separate, after merge)
Fixing the extractor only helps *future* publishes — existing records skip on an
unchanged checksum. A one-off backfill edits their metadata in place (same DOI,
no new version). It's kept **out of this PR** so `main` stays clean; the script +
runbook live on branch `chore/zenodo-author-backfill` and are run after this
merges, then deleted. Rollout: dry-run → canary (`--apply --limit 1`) → full
`--apply`. (The Zenodo sandbox can't be used — we edit existing prod records by id.)

Before that run: fix the "Monika Doeirg" typo in `container_paths_neurodesk`.

Not touched: `template.ipynb` and the old `.md` swi/unwrapping/qsm DOIs already
exist, and published Zenodo DOIs are permanent (no self-delete) — relabel or
leave; a human call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notebook author extraction by scanning the leading markdown header block across multiple markdown cells and stopping at the first code cell.
  - Tightened author label recognition to require a colon after `author`/`authors`, reducing false matches, including template decoys.

- **Tests**
  - Added/expanded regression tests for various notebook layouts and markup formats, including multiple authors and missing author fields.

- **Chores**
  - Updated CI to skip the template notebook to avoid including scaffold content in executed artifacts and minted outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->