### PR TITLE
One-off: Zenodo author backfill tooling + container_paths typo fix

### DIFF
--- a/.github/scripts/BACKFILL_RUNBOOK.md
+++ b/.github/scripts/BACKFILL_RUNBOOK.md
@@ -1,0 +1,55 @@
+# Backfill runbook — fix author metadata on already-published Zenodo DOIs
+
+**One-off remediation.** Corrects records credited to "Neurodesk Project" before
+the author-extraction fix (PR #147). Edits each record's metadata in place —
+**same concept DOI, same version DOI, no new version.**
+
+Run it via the **"Backfill Zenodo Authors (one-off)"** GitHub Action, which uses
+the existing repo secret `ZENODO_TOKEN` (the token never leaves the repo).
+
+> ⚠️ A `workflow_dispatch` workflow is only runnable when its file is on the
+> **default branch (`main`)**. So this tooling (`backfill-zenodo-authors.yml` +
+> `backfill-zenodo-authors.py`) ships to `main` **temporarily**, is run, then is
+> removed by a cleanup PR. The typo fix and the `notebook_metadata.py` fix stay.
+
+## Prerequisites
+- PR #147 (the extractor fix) merged to `main`.
+- The "Monika Doeirg" → "Monika Doerig" typo fix in
+  `container_paths_neurodesk.ipynb` merged to `main` (so the backfill reads the
+  correct name). Folded into the same tooling PR.
+- Repo secret `ZENODO_TOKEN` present (it already is — used by `publish-dois`).
+
+## Run it (Actions → "Backfill Zenodo Authors (one-off)" → Run workflow)
+Do the three dispatches in order, checking the logs/artifact between each:
+
+1. **Dry run** — inputs: `apply = false`. Prints the ~12 planned `old → new`
+   creator changes and writes nothing. Confirm the list looks right.
+2. **Canary** — inputs: `apply = true`, `limit = 1`. Fixes ONE record. Open its
+   DOI on zenodo.org and confirm the creator is corrected and the **DOI is
+   unchanged**.
+3. **Full run** — inputs: `apply = true`, `limit = 0`. Fixes the rest.
+   Optionally set `push_mapping = true` to sync the `authors` field back to the
+   `ci-data` ledger (not required — Zenodo is the source of truth).
+
+## After the run
+- Delete `.github/workflows/backfill-zenodo-authors.yml` and
+  `.github/scripts/backfill-zenodo-authors.py` (+ this runbook) via a cleanup PR.
+
+## Local alternative (keeps `main` untouched)
+If you'd rather not put the workflow on `main`, run the script locally with a
+Zenodo personal token that has `deposit:write` + `deposit:actions`:
+```bash
+git show origin/ci-data:doi-mapping.json > doi-mapping.json
+python .github/scripts/backfill-zenodo-authors.py \
+  --doi-mapping doi-mapping.json --zenodo-token "$ZENODO_TOKEN"            # dry run
+# then --apply --limit 1 (canary), then --apply (full)
+```
+The Zenodo **sandbox can't be used** either way — we edit existing *production*
+records by `record_id`, which don't exist on sandbox; the canary is the safeguard.
+
+## Not handled here (needs a human decision)
+Published Zenodo DOIs are **permanent — they cannot be self-deleted.** Skipped by
+the backfill; relabel their metadata or leave them:
+- `template.ipynb` — a DOI that shouldn't exist (scaffolding).
+- `swi` / `unwrapping` / `qsm` — each has an old `.md` DOI plus the current
+  `.ipynb` DOI (content migrated `.md → .ipynb`).

--- a/.github/scripts/BACKFILL_RUNBOOK.md
+++ b/.github/scripts/BACKFILL_RUNBOOK.md
@@ -22,11 +22,14 @@ the existing repo secret `ZENODO_TOKEN` (the token never leaves the repo).
 ## Run it (Actions → "Backfill Zenodo Authors (one-off)" → Run workflow)
 Do the three dispatches in order, checking the logs/artifact between each:
 
-1. **Dry run** — inputs: `apply = false`. Prints the ~12 planned `old → new`
+1. **Dry run** — inputs: `apply = false`. Prints the **11** planned `old → new`
    creator changes and writes nothing. Confirm the list looks right.
-2. **Canary** — inputs: `apply = true`, `limit = 1`. Fixes ONE record. Open its
-   DOI on zenodo.org and confirm the creator is corrected and the **DOI is
-   unchanged**.
+   (`container_paths_neurodesk.ipynb` is intentionally skipped — the normal
+   pipeline re-publishes it with the correct author when this PR merges.)
+2. **Canary** — inputs: `apply = true`, `limit = 1`. Fixes ONE record. Open the
+   printed **`zenodo.org/records/<record_id>`** page (the version, not the concept
+   DOI) and confirm the creator is corrected and the record's DOI + publication
+   date are **unchanged**.
 3. **Full run** — inputs: `apply = true`, `limit = 0`. Fixes the rest.
    Optionally set `push_mapping = true` to sync the `authors` field back to the
    `ci-data` ledger (not required — Zenodo is the source of truth).

--- a/.github/scripts/backfill-zenodo-authors.py
+++ b/.github/scripts/backfill-zenodo-authors.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""One-off remediation: correct creators on already-published Zenodo records.
+
+Background
+----------
+Records published before the author-extraction fix credit "Neurodesk Project"
+instead of the notebook's real author (their doi-mapping.json entry has
+``authors: []``). Because the publisher short-circuits on an unchanged
+source-cell checksum, simply fixing the extractor does NOT touch these records —
+they only get a new version when the notebook content changes. This script
+corrects them in place.
+
+What it does
+------------
+For each mapping entry it re-extracts the author(s) from the current content file
+and, if that differs from what the record carries, edits the *published* Zenodo
+record's metadata IN PLACE (Zenodo "edit" action → PUT metadata → publish). This
+keeps the same concept DOI and the same version DOI — no new version is minted.
+Metadata is rebuilt with the same ``build_zenodo_metadata`` the normal publisher
+uses, so a corrected record is identical to one freshly published with the fix.
+
+Safety
+------
+- Dry-run by default: prints the planned old→new creators and changes nothing.
+  Pass ``--apply`` to actually edit records.
+- Skips entries where no real author can be extracted (nothing to improve) and
+  entries whose creators already match.
+- ``examples/template.ipynb`` is skipped and flagged: it is scaffolding whose
+  author cell is a placeholder; its existing DOI should be deleted/deprecated by
+  hand rather than re-authored.
+
+Usage
+-----
+    # Dry run (default) against production Zenodo:
+    python .github/scripts/backfill-zenodo-authors.py \
+        --doi-mapping doi-mapping.json --zenodo-token "$ZENODO_TOKEN"
+
+    # Actually apply, and write back the updated mapping:
+    python .github/scripts/backfill-zenodo-authors.py \
+        --doi-mapping doi-mapping.json --output-mapping doi-mapping.json \
+        --zenodo-token "$ZENODO_TOKEN" --apply
+
+Rollout (this edits EXISTING published records by ``record_id``, so the Zenodo
+sandbox cannot mirror them — mitigate risk with a canary instead of sandbox):
+    1. Dry run (default) — inspect the planned old->new creators.
+    2. Canary — ``--apply --limit 1`` against prod, then eyeball that DOI.
+    3. Full run — ``--apply`` for the rest.
+See BACKFILL_RUNBOOK.md for the full post-merge procedure.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+
+from notebook_metadata import extract_authors_from_content
+
+# Reuse the real publisher's metadata builder + retrying HTTP client. Its filename
+# is hyphenated (not a valid module name), so load it by path.
+_PUBLISH_PATH = os.path.join(os.path.dirname(__file__), "publish-zenodo.py")
+_spec = importlib.util.spec_from_file_location("publish_zenodo", _PUBLISH_PATH)
+_pz = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_pz)
+build_zenodo_metadata = _pz.build_zenodo_metadata
+api_request = _pz.api_request
+detect_content_type = _pz.detect_content_type
+
+SKIP_KEYS = {"books/examples/template.ipynb"}
+
+
+def _creator_names(creators):
+    return [c.get("name", "") for c in creators or []]
+
+
+def edit_record_metadata(api_url, record_id, metadata, token):
+    """Unlock a published record, replace its metadata, and re-publish (same DOI)."""
+    # 1. Move the published record into an editable draft state.
+    api_request(
+        f"{api_url}/api/deposit/depositions/{record_id}/actions/edit",
+        method="POST", token=token,
+    )
+    # 2. Replace metadata.
+    api_request(
+        f"{api_url}/api/deposit/depositions/{record_id}",
+        method="PUT", data=json.dumps(metadata).encode(), token=token,
+    )
+    # 3. Re-publish. Same version — no new DOI is minted.
+    api_request(
+        f"{api_url}/api/deposit/depositions/{record_id}/actions/publish",
+        method="POST", token=token,
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--doi-mapping", required=True)
+    ap.add_argument("--output-mapping", help="If given, write the updated mapping here.")
+    ap.add_argument("--zenodo-token", required=True)
+    ap.add_argument("--api-url", default="https://zenodo.org")
+    ap.add_argument("--repo-root", default=".",
+                    help="Repo root that the mapping keys (books/...) are relative to.")
+    ap.add_argument("--site-base-url", default="https://neurodesk.org/edu")
+    ap.add_argument("--apply", action="store_true",
+                    help="Actually edit records. Without this it is a dry run.")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="Process at most N records that need fixing (0 = no limit). "
+                         "Use --limit 1 for a canary run.")
+    args = ap.parse_args()
+
+    with open(args.doi_mapping, encoding="utf-8") as fh:
+        mapping = json.load(fh)
+
+    planned = corrected = skipped = failed = 0
+
+    for key, entry in mapping.items():
+        if args.limit and planned >= args.limit:
+            print(f"Reached --limit={args.limit}; stopping (remaining records untouched).")
+            break
+        record_id = entry.get("record_id")
+        content_path = os.path.join(args.repo_root, key)
+
+        if key in SKIP_KEYS:
+            print(f"SKIP  {key}: template scaffolding — delete/deprecate its DOI by hand "
+                  f"({entry.get('doi_url','')})")
+            skipped += 1
+            continue
+        if not record_id:
+            print(f"SKIP  {key}: no record_id in mapping")
+            skipped += 1
+            continue
+        if not os.path.isfile(content_path):
+            print(f"SKIP  {key}: content file not found at {content_path} "
+                  "(renamed/removed since publish?)")
+            skipped += 1
+            continue
+
+        authors = extract_authors_from_content(content_path)
+        if not authors:
+            print(f"SKIP  {key}: still no author extractable — nothing to correct")
+            skipped += 1
+            continue
+
+        new_creators = [{"name": name} for name in authors]
+        old_creators = entry.get("creators")  # may be absent in older mappings
+        old_names = _creator_names(old_creators) if old_creators else entry.get("authors") or []
+
+        if list(old_names) == authors:
+            skipped += 1
+            continue  # already correct
+
+        planned += 1
+        print(f"FIX   {key}")
+        print(f"        record_id={record_id}  doi={entry.get('doi_url','')}")
+        print(f"        creators: {old_names or ['Neurodesk Project (fallback)']} -> {authors}")
+
+        if not args.apply:
+            continue
+
+        content_type = entry.get("content_type") or detect_content_type(content_path)
+        content_name = os.path.basename(content_path).rsplit(".", 1)[0]
+        page_url = entry.get("website_url") or _pz.build_content_page_url(key, args.site_base_url)
+        metadata = build_zenodo_metadata(
+            content_name=content_name, content_type=content_type,
+            content_key=key, page_url=page_url, creators=new_creators,
+        )
+        try:
+            edit_record_metadata(args.api_url, record_id, metadata, args.zenodo_token)
+            entry["authors"] = authors
+            corrected += 1
+            print("        corrected.")
+        except Exception as exc:  # noqa: BLE001 — one bad record shouldn't abort the batch
+            failed += 1
+            print(f"        ::error:: failed to edit {record_id}: {exc}", file=sys.stderr)
+
+    if args.apply and args.output_mapping:
+        with open(args.output_mapping, "w", encoding="utf-8") as fh:
+            json.dump(mapping, fh, indent=2)
+            fh.write("\n")
+
+    print("\n========== BACKFILL SUMMARY ==========")
+    mode = "APPLIED" if args.apply else "DRY RUN (no changes made)"
+    print(f"Mode:      {mode}")
+    print(f"To fix:    {planned}")
+    if args.apply:
+        print(f"Corrected: {corrected}")
+        print(f"Failed:    {failed}")
+    print(f"Skipped:   {skipped}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/backfill-zenodo-authors.py
+++ b/.github/scripts/backfill-zenodo-authors.py
@@ -16,8 +16,9 @@ For each mapping entry it re-extracts the author(s) from the current content fil
 and, if that differs from what the record carries, edits the *published* Zenodo
 record's metadata IN PLACE (Zenodo "edit" action → PUT metadata → publish). This
 keeps the same concept DOI and the same version DOI — no new version is minted.
-Metadata is rebuilt with the same ``build_zenodo_metadata`` the normal publisher
-uses, so a corrected record is identical to one freshly published with the fix.
+It is read-modify-write: the record's *current* metadata is read and only the
+``creators`` field is changed, so publication_date, description, keywords,
+communities, related_identifiers, etc. are preserved (not reset or dropped).
 
 Safety
 ------
@@ -62,34 +63,46 @@ _PUBLISH_PATH = os.path.join(os.path.dirname(__file__), "publish-zenodo.py")
 _spec = importlib.util.spec_from_file_location("publish_zenodo", _PUBLISH_PATH)
 _pz = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_pz)
-build_zenodo_metadata = _pz.build_zenodo_metadata
 api_request = _pz.api_request
-detect_content_type = _pz.detect_content_type
 
-SKIP_KEYS = {"books/examples/template.ipynb"}
+# Records we deliberately do NOT touch, and why.
+SKIP_KEYS = {
+    "books/examples/template.ipynb":
+        "template scaffolding — its DOI shouldn't exist; handle by hand",
+    # PR #148's typo fix changes this notebook's source, so merging re-publishes it
+    # as a NEW version with the correct author via the normal pipeline. Editing it
+    # here would race that and touch a now-stale record_id.
+    "books/examples/workflows/container_paths_neurodesk.ipynb":
+        "handled by the normal publish pipeline (new version on merge)",
+}
 
 
 def _creator_names(creators):
     return [c.get("name", "") for c in creators or []]
 
 
-def edit_record_metadata(api_url, record_id, metadata, token):
-    """Unlock a published record, replace its metadata, and re-publish (same DOI)."""
-    # 1. Move the published record into an editable draft state.
-    api_request(
-        f"{api_url}/api/deposit/depositions/{record_id}/actions/edit",
-        method="POST", token=token,
-    )
-    # 2. Replace metadata.
-    api_request(
-        f"{api_url}/api/deposit/depositions/{record_id}",
-        method="PUT", data=json.dumps(metadata).encode(), token=token,
-    )
-    # 3. Re-publish. Same version — no new DOI is minted.
-    api_request(
-        f"{api_url}/api/deposit/depositions/{record_id}/actions/publish",
-        method="POST", token=token,
-    )
+def edit_record_metadata(api_url, record_id, new_creators, token):
+    """Correct ONLY the creators of a published record; preserve all other metadata.
+
+    Read-modify-write: unlock the record, read its *current* metadata, replace only
+    the ``creators`` field, then re-publish. Keeps the same concept + version DOI
+    (no new version) and leaves publication_date, description, keywords,
+    communities, related_identifiers, etc. exactly as they were — so it never
+    resets the publication date or clobbers a manual edit.
+    """
+    base = f"{api_url}/api/deposit/depositions/{record_id}"
+    # 1. Unlock the published record into an editable draft state.
+    api_request(f"{base}/actions/edit", method="POST", token=token)
+    # 2. Read the record's CURRENT metadata and change only the creators.
+    deposition = api_request(base, token=token)
+    metadata = dict(deposition.get("metadata") or {})
+    if not metadata:
+        raise RuntimeError(f"no metadata returned for record {record_id}")
+    metadata["creators"] = new_creators
+    # 3. Write it back and re-publish (same version, no new DOI is minted).
+    api_request(base, method="PUT",
+                data=json.dumps({"metadata": metadata}).encode(), token=token)
+    api_request(f"{base}/actions/publish", method="POST", token=token)
 
 
 def main():
@@ -101,7 +114,6 @@ def main():
     ap.add_argument("--api-url", default="https://zenodo.org")
     ap.add_argument("--repo-root", default=".",
                     help="Repo root that the mapping keys (books/...) are relative to.")
-    ap.add_argument("--site-base-url", default="https://neurodesk.org/edu")
     ap.add_argument("--apply", action="store_true",
                     help="Actually edit records. Without this it is a dry run.")
     ap.add_argument("--limit", type=int, default=0,
@@ -122,8 +134,7 @@ def main():
         content_path = os.path.join(args.repo_root, key)
 
         if key in SKIP_KEYS:
-            print(f"SKIP  {key}: template scaffolding — delete/deprecate its DOI by hand "
-                  f"({entry.get('doi_url','')})")
+            print(f"SKIP  {key}: {SKIP_KEYS[key]} ({entry.get('doi_url','')})")
             skipped += 1
             continue
         if not record_id:
@@ -151,27 +162,33 @@ def main():
             continue  # already correct
 
         planned += 1
+        # Log the version-specific record URL (not the concept doi_url), so a canary
+        # reviewer verifies the exact object that was edited.
+        record_url = f"{args.api_url}/records/{record_id}"
         print(f"FIX   {key}")
-        print(f"        record_id={record_id}  doi={entry.get('doi_url','')}")
+        print(f"        {record_url}  (record_id={record_id})")
         print(f"        creators: {old_names or ['Neurodesk Project (fallback)']} -> {authors}")
 
         if not args.apply:
             continue
 
-        content_type = entry.get("content_type") or detect_content_type(content_path)
-        content_name = os.path.basename(content_path).rsplit(".", 1)[0]
-        page_url = entry.get("website_url") or _pz.build_content_page_url(key, args.site_base_url)
-        metadata = build_zenodo_metadata(
-            content_name=content_name, content_type=content_type,
-            content_key=key, page_url=page_url, creators=new_creators,
-        )
         try:
-            edit_record_metadata(args.api_url, record_id, metadata, args.zenodo_token)
+            edit_record_metadata(args.api_url, record_id, new_creators, args.zenodo_token)
             entry["authors"] = authors
             corrected += 1
-            print("        corrected.")
+            print("        corrected (creators only; all other metadata preserved).")
         except Exception as exc:  # noqa: BLE001 — one bad record shouldn't abort the batch
             failed += 1
+            # Best-effort: discard any half-open draft so a broken edit never shadows
+            # the live published record.
+            try:
+                api_request(
+                    f"{args.api_url}/api/deposit/depositions/{record_id}/actions/discard",
+                    method="POST", token=args.zenodo_token, retries=1,
+                )
+                print(f"        rolled back draft for record {record_id}")
+            except Exception:
+                pass
             print(f"        ::error:: failed to edit {record_id}: {exc}", file=sys.stderr)
 
     if args.apply and args.output_mapping:

--- a/.github/scripts/backfill-zenodo-authors.py
+++ b/.github/scripts/backfill-zenodo-authors.py
@@ -81,6 +81,12 @@ def _creator_names(creators):
     return [c.get("name", "") for c in creators or []]
 
 
+def fetch_live_creators(api_url, record_id, token):
+    """Read a published record's CURRENT creators (read-only, no edit)."""
+    dep = api_request(f"{api_url}/api/deposit/depositions/{record_id}", token=token)
+    return (dep.get("metadata") or {}).get("creators") or []
+
+
 def edit_record_metadata(api_url, record_id, new_creators, token):
     """Correct ONLY the creators of a published record; preserve all other metadata.
 
@@ -173,6 +179,14 @@ def main():
             continue
 
         try:
+            # Authoritative check against the LIVE record (the mapping can be stale):
+            # if Zenodo already has the right creators, skip. Makes re-runs idempotent.
+            if _creator_names(fetch_live_creators(args.api_url, record_id, args.zenodo_token)) == authors:
+                print("        already correct on Zenodo — skipping")
+                planned -= 1
+                skipped += 1
+                continue
+
             edit_record_metadata(args.api_url, record_id, new_creators, args.zenodo_token)
             entry["authors"] = authors
             corrected += 1
@@ -187,8 +201,10 @@ def main():
                     method="POST", token=args.zenodo_token, retries=1,
                 )
                 print(f"        rolled back draft for record {record_id}")
-            except Exception:
-                pass
+            except Exception as discard_exc:  # noqa: BLE001
+                print(f"        ::warning::could not roll back draft for record {record_id} "
+                      f"(may be left in edit state — clean up by hand): {discard_exc}",
+                      file=sys.stderr)
             print(f"        ::error:: failed to edit {record_id}: {exc}", file=sys.stderr)
 
     if args.apply and args.output_mapping:

--- a/.github/workflows/backfill-zenodo-authors.yml
+++ b/.github/workflows/backfill-zenodo-authors.yml
@@ -57,23 +57,30 @@ jobs:
           fi
 
       - name: Run backfill
+        # Inputs are passed through env, never interpolated into the shell body,
+        # to avoid script injection from the free-form `limit` input.
         env:
           ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
+          APPLY: ${{ inputs.apply }}
+          LIMIT: ${{ inputs.limit }}
         run: |
           if [ -z "$ZENODO_TOKEN" ]; then
             echo "::error::ZENODO_TOKEN secret is not set"
             exit 1
           fi
+          case "$LIMIT" in
+            ''|*[!0-9]*) echo "::error::limit must be a non-negative integer, got '$LIMIT'"; exit 1;;
+          esac
           APPLY_FLAG=""
-          if [ "${{ inputs.apply }}" = "true" ]; then
+          if [ "$APPLY" = "true" ]; then
             APPLY_FLAG="--apply"
           fi
-          echo "Mode: ${APPLY_FLAG:-dry-run}   limit=${{ inputs.limit }}"
+          echo "Mode: ${APPLY_FLAG:-dry-run}   limit=$LIMIT"
           python3 .github/scripts/backfill-zenodo-authors.py \
             --doi-mapping doi-mapping.json \
             --output-mapping doi-mapping.json \
             --zenodo-token "$ZENODO_TOKEN" \
-            --limit "${{ inputs.limit }}" \
+            --limit "$LIMIT" \
             $APPLY_FLAG
 
       - name: Upload updated doi-mapping.json

--- a/.github/workflows/backfill-zenodo-authors.yml
+++ b/.github/workflows/backfill-zenodo-authors.yml
@@ -1,0 +1,104 @@
+# =============================================================================
+# ONE-OFF: Backfill author metadata on already-published Zenodo records
+# =============================================================================
+# Corrects records credited to "Neurodesk Project" before the author-extraction
+# fix (PR #147). Edits each record's metadata IN PLACE via the Zenodo edit action
+# — same concept DOI, same version DOI, no new version.
+#
+# Manual dispatch only. Uses the existing repo secret ZENODO_TOKEN, so the token
+# never leaves the repo. Recommended sequence (workflow_dispatch inputs):
+#   1. apply = false                 → dry run, prints planned changes, no writes
+#   2. apply = true,  limit = 1      → canary: fix ONE record, then eyeball its DOI
+#   3. apply = true,  limit = 0      → full run
+#
+# DELETE this workflow + .github/scripts/backfill-zenodo-authors.py once the
+# remediation is complete (see .github/scripts/BACKFILL_RUNBOOK.md).
+# =============================================================================
+name: Backfill Zenodo Authors (one-off)
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Actually edit records (unchecked = dry run, no changes)'
+        type: boolean
+        default: false
+      limit:
+        description: 'Max records to fix (0 = all; use 1 for a canary run)'
+        type: string
+        default: '0'
+      push_mapping:
+        description: 'On a full apply, push the updated doi-mapping.json back to ci-data'
+        type: boolean
+        default: false
+
+# Never run two backfills at once against the same Zenodo account.
+concurrency:
+  group: backfill-zenodo-authors
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    name: Backfill author metadata
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write   # only used by the optional push-to-ci-data step
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Load doi-mapping.json from ci-data branch
+        run: |
+          if git fetch origin ci-data 2>/dev/null \
+             && git show origin/ci-data:doi-mapping.json > doi-mapping.json 2>/dev/null; then
+            echo "Loaded doi-mapping.json from ci-data branch"
+          else
+            echo "::error::Could not load doi-mapping.json from ci-data branch"
+            exit 1
+          fi
+
+      - name: Run backfill
+        env:
+          ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
+        run: |
+          if [ -z "$ZENODO_TOKEN" ]; then
+            echo "::error::ZENODO_TOKEN secret is not set"
+            exit 1
+          fi
+          APPLY_FLAG=""
+          if [ "${{ inputs.apply }}" = "true" ]; then
+            APPLY_FLAG="--apply"
+          fi
+          echo "Mode: ${APPLY_FLAG:-dry-run}   limit=${{ inputs.limit }}"
+          python3 .github/scripts/backfill-zenodo-authors.py \
+            --doi-mapping doi-mapping.json \
+            --output-mapping doi-mapping.json \
+            --zenodo-token "$ZENODO_TOKEN" \
+            --limit "${{ inputs.limit }}" \
+            $APPLY_FLAG
+
+      - name: Upload updated doi-mapping.json
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: doi-mapping-backfilled
+          path: doi-mapping.json
+          retention-days: 7
+
+      # Only meaningful after a FULL apply (limit=0). Keeps the ci-data ledger's
+      # `authors` field in sync with Zenodo. Not required for correctness — the
+      # Zenodo record is the source of truth.
+      - name: Push updated doi-mapping.json to ci-data
+        if: ${{ inputs.apply == true && inputs.push_mapping == true && inputs.limit == '0' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          mv doi-mapping.json /tmp/doi-mapping.json
+          git fetch origin ci-data
+          git checkout ci-data
+          cp /tmp/doi-mapping.json doi-mapping.json
+          git add doi-mapping.json
+          if git diff --cached --quiet; then
+            echo "No changes to doi-mapping.json"
+          else
+            git commit -m "chore: backfill author metadata in doi-mapping.json"
+            git push origin ci-data
+          fi

--- a/books/examples/workflows/container_paths_neurodesk.ipynb
+++ b/books/examples/workflows/container_paths_neurodesk.ipynb
@@ -15,7 +15,7 @@
    "id": "5cb89d98",
    "metadata": {},
    "source": [
-    "**Author**: Monika Doeirg\n",
+    "**Author**: Monika Doerig\n",
     "\n",
     "**Date**: 08 May 2026\n",
     "\n",


### PR DESCRIPTION
Follow-up to #147 (which fixed author extraction *going forward*). This adds the
one-off remediation for the **already-published** DOIs still credited to
"Neurodesk Project", plus a notebook author typo fix.

## Contents

**Permanent**
- `container_paths_neurodesk.ipynb` — fix author typo: `Monika Doeirg` → `Monika Doerig`.

**One-off tooling** (removed by a cleanup PR after the run — see runbook)
- `.github/workflows/backfill-zenodo-authors.yml` — manual `workflow_dispatch` that
  edits existing Zenodo records' creators **in place** (same concept DOI, same
  version DOI, no new version), using the existing `ZENODO_TOKEN` secret.
- `.github/scripts/backfill-zenodo-authors.py` — the backfill (dry-run by default,
  `--limit` for a canary; reuses `publish-zenodo.py`'s metadata builder).
- `.github/scripts/BACKFILL_RUNBOOK.md` — the procedure.

## How the backfill runs (after merge — manual)

Actions → **Backfill Zenodo Authors (one-off)** → Run workflow:
1. `apply=false` → dry run (prints the ~12 planned `old → new` changes)
2. `apply=true, limit=1` → canary (fix one record, verify the DOI is unchanged)
3. `apply=true, limit=0` → full run

Then a cleanup PR removes the workflow + script + runbook.

## ⚠️ Merge side-effects (expected, not a surprise)

Because this PR edits a notebook, merging triggers the normal pipeline to
re-execute and **re-publish `container_paths_neurodesk` to Zenodo as a new version**
(now with the correct author) + deploy Pages. That fixes that one record via the
standard path — so the backfill then only needs the other **11** (no-content-change)
records that the normal pipeline never revisits.

## Hardening (after a paranoid review)

- The backfill uses **read-modify-write**: it reads each record's *current*
  metadata and changes **only `creators`**, so `publication_date`, description,
  keywords, communities, etc. are preserved (an earlier draft rebuilt full
  metadata, which would have reset the publication date and dropped fields).
- `container_paths_neurodesk.ipynb` is **excluded** from the backfill — the normal
  pipeline re-publishes it on merge, so editing it here would race a stale
  `record_id`.
- On failure it discards the half-open draft (never shadows the live record); it
  logs the version `records/<id>` URL for canary verification.

## Simulated

Dry-run against the live `ci-data` `doi-mapping.json`: **11 records to fix**, with
`container_paths` (handled by the pipeline), `template.ipynb`, and the stale `.md`
duplicates (`swi`/`unwrapping`/`qsm`) correctly skipped. Published Zenodo DOIs are
permanent (no self-delete), so those skipped ones are a separate human call. The
extractor fix itself was verified
across all 57 notebooks in #147.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected an author name spelling in the Neurodesk container paths example.
  - Added a controlled process to correct author metadata on previously published Zenodo records while preserving DOI and version information.

- **Documentation**
  - Added guidance for previewing, applying, and verifying Zenodo author metadata corrections, including cleanup steps for the temporary remediation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->